### PR TITLE
Added mocking for Neblio API methods

### DIFF
--- a/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionHelpers.cs
+++ b/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionHelpers.cs
@@ -2131,6 +2131,15 @@ namespace VEDriversLite
         }
 
         /// <summary>
+        /// This method is written for Unit tests to pass in Mock client object
+        /// </summary>
+        /// <param name="client"></param>
+        public static void GetClient(IClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
         /// Send request for creating RAW token transaction
         /// </summary>
         /// <param name="data"></param>

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/CheckSpendableNeblioTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/CheckSpendableNeblioTest.cs
@@ -1,13 +1,23 @@
-﻿using System;
+﻿using Moq;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using VEDriversLite.Neblio;
+using VEDriversLite.NeblioAPI;
+using VEDriversLite;
 using Xunit;
 
 namespace VEFrameworkUnitTest
 {
     public class CheckSpendableNeblioTest : NeblioAccountBase
     {
+        private Mock<IClient> _client = new Mock<IClient>();
+
+        public CheckSpendableNeblioTest()
+        {
+            NeblioTransactionHelpers.GetClient(_client.Object);
+        }
+
         /// <summary>
         /// Unit test method to verify if system is returning an error result if an address is not having enough Neblio.
         /// </summary>
@@ -16,7 +26,12 @@ namespace VEFrameworkUnitTest
         {
             var count = 2;
             this.Address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWd";
+
+            var getAddressInfoResponse = new GetAddressInfoResponse();
+            _client.Setup(x => x.GetAddressInfoAsync(It.IsAny<string>())).ReturnsAsync(getAddressInfoResponse);           
+
             var result = this.CheckSpendableNeblio(0.23).Result;
+
             string error = "You dont have Neblio on the address. Probably waiting for more than " + count +
                            " confirmations.";
 
@@ -31,8 +46,92 @@ namespace VEFrameworkUnitTest
         public void CheckSpendableNeblio_Valid_Test()
         {            
             this.Address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh";
-            var result1 = this.CheckSpendableNeblio(0.23).Result;
-            string ok = "OK";
+
+            #region TransactionObject
+
+            string sampleTransactionObject = "{\"hex\":\"\",\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"version\":1.0,\"locktime\":0.0,\"vin\"" +
+                                           ":[{\"txid\":\"3e1fb1d4dd68fa6cfc87546d46f84700d3ec8c4ad30379aeebbefbfc846e1a0c\",\"vout\":0.0,\"scriptSig\":" +
+                                           "{\"asm\":\"304402202cfb5f83b09523cbbad30c645bc7732d8f373e9db7beded80d647b5a9f7c470302203a9d3b0c8179489457d1a195449b1152dbac4a93036c041721e9043448bb693801" +
+                                           " 03e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\",\"hex\":" +
+                                           "\"47304402202cfb5f83b09523cbbad30c645bc7732d8f373e9db7beded80d647b5a9f7c470302203a9d3b0c8179489457d1a195449b1152dbac4a93036c041721e9043448bb6938012103e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\"}" +
+                                           ",\"sequence\":4294967295.0,\"previousOutput\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"," +
+                                           "\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]}," +
+                                           "\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":100.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                                           "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"value\":10000.0,\"fixed\":true,\"doubleSpentTxid\":\"70db343273615e939b3a268a08f93974b13d335052059ddfa11d24f8f0533fbe\"}," +
+                                           "{\"txid\":\"3e1fb1d4dd68fa6cfc87546d46f84700d3ec8c4ad30379aeebbefbfc846e1a0c\",\"vout\":2.0,\"scriptSig\":{\"asm\":" +
+                                           "\"3044022058927def6c4edfeee8c69afe054762d588a18b5289a47d038805473b57aeb6bc02205f6ab7e14c62e81baab44046aea04cbbf41f56f9bbde57032289fe172fbc1ed701" +
+                                           " 03e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\",\"hex\":\"473044022058927def6c4edfeee8c69afe054762d588a18b5289a47d038805473b57aeb6bc02205f6ab7e14c62e81baab44046aea04cbbf41f56f9bbde57032289fe172fbc1ed7012103e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\"}," +
+                                           "\"sequence\":4294967295.0,\"previousOutput\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]}," +
+                                           "\"tokens\":[],\"value\":5000000.0,\"fixed\":true,\"doubleSpentTxid\":\"70db343273615e939b3a268a08f93974b13d335052059ddfa11d24f8f0533fbe\"}],\"vout\":[{\"value\":10000.0,\"n\":0.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"" +
+                                           ",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                                           ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":1.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"," +
+                                           "\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                                           ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":2.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                                           ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                                           "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":3.0,\"scriptPubKey\":{\"asm\":\"\",\"hex\":\"\",\"type\":\"nulldata\"},\"tokens\":[],\"used\":false,\"blockheight\":3627327.0," +
+                                           "\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":4930000.0,\"n\":4.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\"" +
+                                           ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":5.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\"" +
+                                           ",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":97.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true," +
+                                           "\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null}],\"blocktime\":1640788684000.0,\"blockheight\":3627327.0,\"totalsent\":4980000.0,\"fee\":30000.0,\"blockhash\":\"45e0f23add155af31ffcc06304384406212465222782194866654ccf359b7ddd\",\"time\"" +
+                                           ":1640788684000.0,\"confirmations\":65021.0,\"doubleSpent\":true,\"tries\":0}";
+
+            #endregion
+            GetTransactionInfoResponse transactionObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetTransactionInfoResponse>(sampleTransactionObject);
+
+            #region AddressObject
+
+            //AddressInfoResponse
+            var addressResponseObject = "{\"address\":\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\",\"utxos\":[{\"index\":1.0,\"txid\":\"cc1d7ca4e918d35dbee5018340a28a6cc6b3ede9a1ad76ea2f793abc3150186f\"," +
+                "\"blockheight\":3664058.0,\"blocktime\":1641909889000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"" +
+                ",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\"" +
+                ":false,\"value\":500000000.0,\"tokens\":[]},{\"index\":5.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0," +
+                "\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":" +
+                "\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false," +
+                "\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":97.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":4.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\"," +
+                "\"blockheight\":3627327.0,\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":" +
+                "4930000.0,\"tokens\":[]},{\"index\":2.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0,\"blocktime\":1640788684000.0," +
+                "\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\"" +
+                ",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\"" +
+                ",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]}," +
+                "{\"index\":1.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0,\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":" +
+                "\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":" +
+                "\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\"" +
+                ":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\"" +
+                ":0.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0,\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160" +
+                " 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\"" +
+                ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":" +
+                "\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":3.0,\"txid\":" +
+                "\"5f424d06bc12c96cb4f6deef300a43cb4cb65e2be022c02a791fa428808bf2e0\",\"blockheight\":3619186.0,\"blocktime\":1640539674000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 " +
+                "2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\"" +
+                ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":98.0,\"issueTxid\":" +
+                "\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":2.0,\"txid\":" +
+                "\"5f424d06bc12c96cb4f6deef300a43cb4cb65e2be022c02a791fa428808bf2e0\",\"blockheight\":3619186.0,\"blocktime\":1640539674000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 " +
+                "2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\"," +
+                "\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":4870000.0,\"tokens\":[]},{\"index\":0.0,\"txid\":\"5f424d06bc12c96cb4f6deef300a43cb4cb65e2be022c02a791fa428808bf2e0\"" +
+                ",\"blockheight\":3619186.0,\"blocktime\":1640539674000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0," +
+                "\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0" +
+                ",\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":1.0,\"txid\":\"7ac89ab228f76ac4a85c1af5359ee299e439aaf4d858d859f09fcee54256f467\",\"blockheight\":3613121.0" +
+                ",\"blocktime\":1640355136000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":" +
+                "\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\"" +
+                ":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":2.0,\"txid\":\"e0986671ec79ac674c7a7929ec9ec5fa0a130c221ddddfd06ff13c423343ce7a\"," +
+                "\"blockheight\":3613117.0,\"blocktime\":1640354975000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":50000.0,\"tokens\":[]}]}";
+
+            #endregion
+
+            GetAddressInfoResponse addressObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetAddressInfoResponse>(addressResponseObject);
+
+            _client.Setup(x => x.GetAddressInfoAsync(It.IsAny<string>())).ReturnsAsync(addressObject);
+            
+            _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);            
+
+            var result1 = CheckSpendableNeblio(0.23).Result;
+
+            const string ok = "OK";
             Assert.Equal(ok, result1.Item1);
             Assert.NotEmpty(result1.Item2);
         }

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetAddressNeblUtxoTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetAddressNeblUtxoTest.cs
@@ -1,22 +1,112 @@
-﻿using System;
+﻿using Moq;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using VEDriversLite;
+using VEDriversLite.NeblioAPI;
 using Xunit;
 
 namespace VEFrameworkUnitTest
 {
     public class GetAddressNeblUtxoTest
     {
+        private Mock<IClient> _client = new Mock<IClient>();
+
+        public GetAddressNeblUtxoTest()
+        {
+            NeblioTransactionHelpers.GetClient(_client.Object);
+        }
+
         /// <summary>
         /// Unit test method to verify if system is returning Utxos for a valid address and required amount is found.
         /// </summary>
         [Fact]
         public void GetAddressNeblUtxo_Valid_Test()
         {
+            #region TransactionObject
+
+            string sampleTransactionObject = "{\"hex\":\"\",\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"version\":1.0,\"locktime\":0.0,\"vin\"" +
+                                           ":[{\"txid\":\"3e1fb1d4dd68fa6cfc87546d46f84700d3ec8c4ad30379aeebbefbfc846e1a0c\",\"vout\":0.0,\"scriptSig\":" +
+                                           "{\"asm\":\"304402202cfb5f83b09523cbbad30c645bc7732d8f373e9db7beded80d647b5a9f7c470302203a9d3b0c8179489457d1a195449b1152dbac4a93036c041721e9043448bb693801" +
+                                           " 03e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\",\"hex\":" +
+                                           "\"47304402202cfb5f83b09523cbbad30c645bc7732d8f373e9db7beded80d647b5a9f7c470302203a9d3b0c8179489457d1a195449b1152dbac4a93036c041721e9043448bb6938012103e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\"}" +
+                                           ",\"sequence\":4294967295.0,\"previousOutput\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"," +
+                                           "\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]}," +
+                                           "\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":100.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                                           "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"value\":10000.0,\"fixed\":true,\"doubleSpentTxid\":\"70db343273615e939b3a268a08f93974b13d335052059ddfa11d24f8f0533fbe\"}," +
+                                           "{\"txid\":\"3e1fb1d4dd68fa6cfc87546d46f84700d3ec8c4ad30379aeebbefbfc846e1a0c\",\"vout\":2.0,\"scriptSig\":{\"asm\":" +
+                                           "\"3044022058927def6c4edfeee8c69afe054762d588a18b5289a47d038805473b57aeb6bc02205f6ab7e14c62e81baab44046aea04cbbf41f56f9bbde57032289fe172fbc1ed701" +
+                                           " 03e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\",\"hex\":\"473044022058927def6c4edfeee8c69afe054762d588a18b5289a47d038805473b57aeb6bc02205f6ab7e14c62e81baab44046aea04cbbf41f56f9bbde57032289fe172fbc1ed7012103e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\"}," +
+                                           "\"sequence\":4294967295.0,\"previousOutput\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]}," +
+                                           "\"tokens\":[],\"value\":5000000.0,\"fixed\":true,\"doubleSpentTxid\":\"70db343273615e939b3a268a08f93974b13d335052059ddfa11d24f8f0533fbe\"}],\"vout\":[{\"value\":10000.0,\"n\":0.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"" +
+                                           ",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                                           ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":1.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"," +
+                                           "\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                                           ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":2.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                                           ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                                           "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":3.0,\"scriptPubKey\":{\"asm\":\"\",\"hex\":\"\",\"type\":\"nulldata\"},\"tokens\":[],\"used\":false,\"blockheight\":3627327.0," +
+                                           "\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":4930000.0,\"n\":4.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\"" +
+                                           ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":5.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\"" +
+                                           ",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":97.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true," +
+                                           "\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null}],\"blocktime\":1640788684000.0,\"blockheight\":3627327.0,\"totalsent\":4980000.0,\"fee\":30000.0,\"blockhash\":\"45e0f23add155af31ffcc06304384406212465222782194866654ccf359b7ddd\",\"time\"" +
+                                           ":1640788684000.0,\"confirmations\":65021.0,\"doubleSpent\":true,\"tries\":0}";
+
+            #endregion
+            GetTransactionInfoResponse transactionObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetTransactionInfoResponse>(sampleTransactionObject);
+
+            #region AddressObject
+
+            //AddressInfoResponse
+            var response = "{\"address\":\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\",\"utxos\":[{\"index\":1.0,\"txid\":\"cc1d7ca4e918d35dbee5018340a28a6cc6b3ede9a1ad76ea2f793abc3150186f\"," +
+                "\"blockheight\":3664058.0,\"blocktime\":1641909889000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"" +
+                ",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\"" +
+                ":false,\"value\":500000000.0,\"tokens\":[]},{\"index\":5.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0," +
+                "\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":" +
+                "\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false," +
+                "\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":97.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":4.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\"," +
+                "\"blockheight\":3627327.0,\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":" +
+                "4930000.0,\"tokens\":[]},{\"index\":2.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0,\"blocktime\":1640788684000.0," +
+                "\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\"" +
+                ",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\"" +
+                ",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]}," +
+                "{\"index\":1.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0,\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":" +
+                "\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":" +
+                "\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\"" +
+                ":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\"" +
+                ":0.0,\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"blockheight\":3627327.0,\"blocktime\":1640788684000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160" +
+                " 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\"" +
+                ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":" +
+                "\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":3.0,\"txid\":" +
+                "\"5f424d06bc12c96cb4f6deef300a43cb4cb65e2be022c02a791fa428808bf2e0\",\"blockheight\":3619186.0,\"blocktime\":1640539674000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 " +
+                "2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\"" +
+                ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":98.0,\"issueTxid\":" +
+                "\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":2.0,\"txid\":" +
+                "\"5f424d06bc12c96cb4f6deef300a43cb4cb65e2be022c02a791fa428808bf2e0\",\"blockheight\":3619186.0,\"blocktime\":1640539674000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 " +
+                "2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\"," +
+                "\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":4870000.0,\"tokens\":[]},{\"index\":0.0,\"txid\":\"5f424d06bc12c96cb4f6deef300a43cb4cb65e2be022c02a791fa428808bf2e0\"" +
+                ",\"blockheight\":3619186.0,\"blocktime\":1640539674000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":10000.0," +
+                "\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0" +
+                ",\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":1.0,\"txid\":\"7ac89ab228f76ac4a85c1af5359ee299e439aaf4d858d859f09fcee54256f467\",\"blockheight\":3613121.0" +
+                ",\"blocktime\":1640355136000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":" +
+                "\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\"" +
+                ":10000.0,\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}]},{\"index\":2.0,\"txid\":\"e0986671ec79ac674c7a7929ec9ec5fa0a130c221ddddfd06ff13c423343ce7a\"," +
+                "\"blockheight\":3613117.0,\"blocktime\":1640354975000.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"used\":false,\"value\":50000.0,\"tokens\":[]}]}";
+
+            #endregion
+
             //Arrange           
-            string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh";
-            double amount = 3;
+            string address = "123";
+            double amount = 3;            
+
+            GetAddressInfoResponse addressObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetAddressInfoResponse>(response);                                          
+
+            _client.Setup(x => x.GetAddressInfoAsync(It.IsAny<string>())).ReturnsAsync(addressObject);
+            _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);                                    
 
             //ACT
             var Utxos = NeblioTransactionHelpers.GetAddressNeblUtxo(address, 0.0001, amount).Result;
@@ -30,10 +120,23 @@ namespace VEFrameworkUnitTest
         /// </summary>
         [Fact]
         public void GetSendAmount_EmptyUtxos_Test()
-        {
+        {                        
             //Arrange
-            string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdhqw"; //Incorrect Address
+            string address = "123";
             double amount = 3;
+
+            var addressResponse = new GetAddressInfoResponse()
+            {
+                Utxos = new List<Utxos>()
+            };
+
+            var transactionInfoResponse = new GetTransactionInfoResponse()
+            {
+                Vin = new List<Vin>()
+            };
+
+            _client.Setup(x => x.GetAddressInfoAsync(It.IsAny<string>())).ReturnsAsync(addressResponse);
+            _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionInfoResponse);
 
             //ACT
             var Utxos = NeblioTransactionHelpers.GetAddressNeblUtxo(address, 0.0001, amount).Result;

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetSendAmountTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetSendAmountTest.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using Moq;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using VEDriversLite;
+using VEDriversLite.NeblioAPI;
 using Xunit;
 
 namespace VEFrameworkUnitTest
@@ -9,18 +11,58 @@ namespace VEFrameworkUnitTest
     public class GetSendAmountTest
     {
         /// <summary>
+        /// 
+        /// </summary>
+        private Mock<IClient> _client = new Mock<IClient>();
+
+        public GetSendAmountTest()
+        {
+            NeblioTransactionHelpers.GetClient(_client.Object);
+        }
+
+        /// <summary>
         /// Unit test method to verify if system is returning amount correctly.
         /// </summary>
         [Fact]
         public void GetSendAmount_Valid_Test()
         {
             //Arrange
-            var transactionId = "cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb";
+            var transactionId = "123";
             string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh";
+
+            string sampleTransactionObject = "{\"hex\":\"\",\"txid\":\"cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb\",\"version\":1.0,\"locktime\":0.0,\"vin\"" +
+                                            ":[{\"txid\":\"3e1fb1d4dd68fa6cfc87546d46f84700d3ec8c4ad30379aeebbefbfc846e1a0c\",\"vout\":0.0,\"scriptSig\":" +
+                                            "{\"asm\":\"304402202cfb5f83b09523cbbad30c645bc7732d8f373e9db7beded80d647b5a9f7c470302203a9d3b0c8179489457d1a195449b1152dbac4a93036c041721e9043448bb693801" +
+                                            " 03e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\",\"hex\":" +
+                                            "\"47304402202cfb5f83b09523cbbad30c645bc7732d8f373e9db7beded80d647b5a9f7c470302203a9d3b0c8179489457d1a195449b1152dbac4a93036c041721e9043448bb6938012103e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\"}" +
+                                            ",\"sequence\":4294967295.0,\"previousOutput\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"," +
+                                            "\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]}," +
+                                            "\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":100.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                                            "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"value\":10000.0,\"fixed\":true,\"doubleSpentTxid\":\"70db343273615e939b3a268a08f93974b13d335052059ddfa11d24f8f0533fbe\"}," +
+                                            "{\"txid\":\"3e1fb1d4dd68fa6cfc87546d46f84700d3ec8c4ad30379aeebbefbfc846e1a0c\",\"vout\":2.0,\"scriptSig\":{\"asm\":" +
+                                            "\"3044022058927def6c4edfeee8c69afe054762d588a18b5289a47d038805473b57aeb6bc02205f6ab7e14c62e81baab44046aea04cbbf41f56f9bbde57032289fe172fbc1ed701" +
+                                            " 03e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\",\"hex\":\"473044022058927def6c4edfeee8c69afe054762d588a18b5289a47d038805473b57aeb6bc02205f6ab7e14c62e81baab44046aea04cbbf41f56f9bbde57032289fe172fbc1ed7012103e295cd7e4bdc5005d185abc88b896a92aa2f32697df7255ee9a9eb4a1f121817\"}," +
+                                            "\"sequence\":4294967295.0,\"previousOutput\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]}," +
+                                            "\"tokens\":[],\"value\":5000000.0,\"fixed\":true,\"doubleSpentTxid\":\"70db343273615e939b3a268a08f93974b13d335052059ddfa11d24f8f0533fbe\"}],\"vout\":[{\"value\":10000.0,\"n\":0.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"" +
+                                            ",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                                            ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":1.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\"," +
+                                            "\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"" +
+                                            ",\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":2.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\"" +
+                                            ":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":1.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\"," +
+                                            "\"divisibility\":7.0,\"lockStatus\":true,\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":3.0,\"scriptPubKey\":{\"asm\":\"\",\"hex\":\"\",\"type\":\"nulldata\"},\"tokens\":[],\"used\":false,\"blockheight\":3627327.0," +
+                                            "\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":4930000.0,\"n\":4.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\"" +
+                                            ":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null},{\"value\":10000.0,\"n\":5.0,\"scriptPubKey\":{\"asm\":\"OP_DUP OP_HASH160 2c026bcdd04c8154d7cc73841914ffe33fcb3568 OP_EQUALVERIFY OP_CHECKSIG\",\"hex\":\"76a9142c026bcdd04c8154d7cc73841914ffe33fcb356888ac\"" +
+                                            ",\"reqSigs\":1.0,\"type\":\"pubkeyhash\",\"addresses\":[\"NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh\"]},\"tokens\":[{\"tokenId\":\"La58e9EeXUMx41uyfqk6kgVWAQq9yBs44nuQW8\",\"amount\":97.0,\"issueTxid\":\"49ad447c7fc9dc3b8203a42b76f80dd5b79ccaa3cb7e9723e9ac05fb4c70c32c\",\"divisibility\":7.0,\"lockStatus\":true," +
+                                            "\"aggregationPolicy\":\"aggregatable\"}],\"used\":false,\"blockheight\":3627327.0,\"usedBlockheight\":null,\"usedTxid\":null}],\"blocktime\":1640788684000.0,\"blockheight\":3627327.0,\"totalsent\":4980000.0,\"fee\":30000.0,\"blockhash\":\"45e0f23add155af31ffcc06304384406212465222782194866654ccf359b7ddd\",\"time\"" +
+                                            ":1640788684000.0,\"confirmations\":65021.0,\"doubleSpent\":true,\"tries\":0}";
+
+            GetTransactionInfoResponse transactionObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetTransactionInfoResponse>(sampleTransactionObject);
+
+            _client.Setup(x => x.GetTransactionInfoAsync(transactionId)).ReturnsAsync(transactionObject);
 
             //ACT
             var txinfo = NeblioTransactionHelpers.GetTransactionInfo(transactionId).Result;
-            var amount = NeblioTransactionHelpers.GetSendAmount(txinfo, address).Result;            
+            var amount = NeblioTransactionHelpers.GetSendAmount(txinfo, address).Result;
 
             //Assert  
             Assert.True(amount > 0);
@@ -37,12 +79,46 @@ namespace VEFrameworkUnitTest
             string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThW"; //Incorrect address
             string message = "Cannot get amount of transaction. cannot create receiver address!";
 
-            //ACT
+            var transactionObject = new GetTransactionInfoResponse()
+            {
+                Vin = new List<Vin>(),
+                Vout = new List<Vout>()
+            };
+
+            _client.Setup(x => x.GetTransactionInfoAsync(transactionId)).ReturnsAsync(transactionObject);
+
+            //ACT            
             var txinfo = NeblioTransactionHelpers.GetTransactionInfo(transactionId).Result;
 
             //Assert
             var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.GetSendAmount(txinfo, address)).Result;
             Assert.Equal(message, exception.Message);
+        }
+
+        /// <summary>
+        /// Unit test method to verify if system is returning an error result for incorrect address and incorrect transactionId.
+        /// </summary>
+        [Fact]
+        public void GetSendAmount_EmptyInAndOutVectors_Test()
+        {
+            //Arrange
+            var transactionId = "cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6"; //Incorrect transactionId
+            string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh"; 
+
+            var emptyTransactionObject = new GetTransactionInfoResponse()
+            {
+                Vin = new List<Vin>(),
+                Vout = new List<Vout>()
+            };
+
+            _client.Setup(x => x.GetTransactionInfoAsync(transactionId)).ReturnsAsync(emptyTransactionObject);
+
+            //ACT            
+            var txinfo = NeblioTransactionHelpers.GetTransactionInfo(transactionId).Result;
+            double amount = NeblioTransactionHelpers.GetSendAmount(txinfo, address).Result;
+
+            //Assert
+            Assert.Equal(0, amount);
         }
     }
 }


### PR DESCRIPTION
Created a framework to add mock on Neblio API methods for Unit test cases wherever applicable.
Changes:
1. Have added the instance of the mocked object in the constructor of test classes.
2. New public method in NeblioTransactionHelpers.cs to initialize the mock _client object.
3. Changes in test classes to include code for mocking Neblio api endpoints. 