### PR TITLE
Storing Latest blockheight in cache

### DIFF
--- a/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionsCache.cs
+++ b/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionsCache.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.Caching;
+using System.Timers;
+using VEDriversLite.NeblioAPI;
+
+namespace VEDriversLite.Neblio
+{
+    /// <summary>
+    /// This class will query Neblio API with the input address, stores the BlockHeight from address's latest Utxo in Cache.
+    /// Cache will expiry for every 10 seconds so when accessed system will check cache and return the latest blockheight 
+    /// </summary>
+    public static class NeblioTransactionsCache
+    {
+        private static readonly object _lockObject = new object();
+
+        /// <summary>
+        /// Method will check if the data for current address is available in cache and returns the blockheight, IF not avaialble then retrievs from API.
+        /// </summary>
+        /// <param name="address">The address for which we need the latest block height</param>
+        /// <returns></returns>
+        public static double LatestBlockHeight(string address)
+        {
+            lock (_lockObject)
+            {
+                ObjectCache cache = MemoryCache.Default;
+                double blockHeightValue;
+                if (cache.Contains(address))
+                {
+                    blockHeightValue = (double)cache.Get(address);
+                }
+                else
+                {
+                    blockHeightValue = GetLatestTransaction(address);
+                }
+                return blockHeightValue;
+            }
+        }
+
+        /// <summary>
+        /// Method will get the Utxos list for the address and return the latest block height. The data will be added to cache with 10 seconds as expiration time.
+        /// </summary>
+        /// <param name="address">The address for which we need the latest block height</param>
+        /// <returns></returns>
+        private static double GetLatestTransaction(string address)
+        {
+            ObjectCache cache = MemoryCache.Default;
+
+            CacheItemPolicy cacheItemPolicy = new CacheItemPolicy
+            {
+                AbsoluteExpiration = DateTime.Now.AddMilliseconds(10000)
+            };
+
+            GetAddressInfoResponse data = NeblioTransactionHelpers.GetClient().GetAddressInfoAsync(address).Result;
+            if (data.Utxos.Count == 0)
+            {
+                return 0;
+            }
+            List<Utxos> utxos = (List<Utxos>)data.Utxos;
+            double blockHeightValue = utxos[0].Blockheight.Value;
+
+            if (cache.Contains(address))
+            {
+                cache.Remove(address);
+            }
+            cache.Add(address, blockHeightValue, cacheItemPolicy);
+            return blockHeightValue;
+        }
+    }
+}

--- a/VirtualEconomyFramework/VEDriversLite/VEDriversLite.csproj
+++ b/VirtualEconomyFramework/VEDriversLite/VEDriversLite.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Ipfs.Http.Client" Version="0.33.0" />
     <PackageReference Include="NBitcoin" Version="5.0.81" />
     <PackageReference Include="NBitcoin.Altcoins" Version="2.0.33" />
+    <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
     <PackageReference Include="WordPressPCL" Version="1.9.0" />
     <!--<PackageReference Include="QRCoder" Version="1.4.1" />-->
     <!--<PackageReference Include="ZXing.Net" Version="0.16.6" />-->

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/CheckSpendableNeblioTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/CheckSpendableNeblioTest.cs
@@ -129,7 +129,7 @@ namespace VEFrameworkUnitTest.Neblio
             
             _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);            
 
-            var result1 = CheckSpendableNeblio(0.23).Result;
+            var result1 = CheckSpendableNeblio(0.0009).Result;
 
             const string ok = "OK";
             Assert.Equal(ok, result1.Item1);

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetAddressNeblUtxoTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetAddressNeblUtxoTest.cs
@@ -101,7 +101,7 @@ namespace VEFrameworkUnitTest.Neblio
 
             //Arrange           
             string address = "123";
-            double amount = 3;            
+            double amount = 0.009;            
 
             GetAddressInfoResponse addressObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetAddressInfoResponse>(response);                                          
 

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/SendNeblioTransactionTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/SendNeblioTransactionTest.cs
@@ -135,7 +135,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);
             _client.Setup(x => x.BroadcastTxAsync(It.IsAny<BroadcastTxRequest>())).ReturnsAsync(broadcastTxResponse);
 
-            var result = CheckSpendableNeblio(.1).Result;
+            var result = CheckSpendableNeblio(.0009).Result;
 
             var AccountKey = new EncryptionKey(Key)
             {
@@ -576,7 +576,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);
             _client.Setup(x => x.BroadcastTxAsync(It.IsAny<BroadcastTxRequest>())).ReturnsAsync(broadcastTxResponse);
 
-            var result = CheckSpendableNeblio(.1).Result;
+            var result = CheckSpendableNeblio(.0009).Result;
 
             var AccountKey = new EncryptionKey(Key)
             {


### PR DESCRIPTION
New class NeblioTransactionCache to query Neblio API with the input address, to stores the BlockHeight from address's latest Utxo in Cache.

Changes in NeblioTransactionhelper to consume the cache.