### PR TITLE
Get rid of AntDesign in VENTF App - Spin component

### DIFF
--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/CreateAccount.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/CreateAccount.razor
@@ -12,7 +12,7 @@
        OnCancel="@HandleCancel">
     <div class="row">
         <div class="col">
-            <Spin spinning="@creatingAddressSpinner" tip="Creating Address...">
+            <VENFTApp_Blazor.Components.Spin Spinning="@creatingAddressSpinner" Tip="Creating Address...">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         <h6>Welcome in VENFT App</h6>
@@ -114,7 +114,7 @@
                         }
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/ImportAccount.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/ImportAccount.razor
@@ -18,7 +18,7 @@
        OnCancel="@importAccountCancel">
     <div class="row">
         <div class="col">
-            <Spin spinning="@creatingAddressSpinner" tip="Importing Address...">
+            <VENFTApp_Blazor.Components.Spin Spinning="@creatingAddressSpinner" Tip="Importing Address...">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         <h6>Option 1</h6>
@@ -137,7 +137,7 @@
                            Description="Wrong Password or private key"
                            ShowIcon="true" />
                 }
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/SignAndVerifyMessage.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/SignAndVerifyMessage.razor
@@ -5,7 +5,7 @@
         <h5 class="text-center w-100">Message signatures</h5>
     </div>
     <div class="card-body d-flex justify-content-center align-items-center" style="padding: 5px;padding-left: 20px;padding-right: 20px;padding-bottom: 10px; min-height:620px; max-height:800px; max-width:350px;">
-        <Spin Tip="Processing..." Spinning="@processing">
+        <VENFTApp_Blazor.Components.Spin Tip="Processing..." Spinning="@processing">
             <div class="row d-flex justify-content-center align-items-center w-100">
                 <div class="col w-auto">
                     @if (DisplaySign)
@@ -142,7 +142,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/TransactionDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/TransactionDetails.razor
@@ -5,7 +5,7 @@
 
 <div class="row d-flex justify-content-center align-items-center">
     <div class="col">
-        <Spin Tip="Loading..." Spinning="@txDetailsLoading">
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@txDetailsLoading">
             <div class="row d-flex justify-content-center align-items-center">
                 <div class="col">
                     <div class="row">
@@ -148,7 +148,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/TransactionsList.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/TransactionsList.razor
@@ -5,7 +5,7 @@
 <div class="row w-100 m-0 d-flex justify-content-center align-items-center">
     @if (TransactionsDetails == null)
     {
-        <p><em><Spin Tip="Loading..." /></em></p>
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." />
     }
     else
     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/UnlockAccount.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Account/UnlockAccount.razor
@@ -17,7 +17,7 @@
        OnCancel="@UnclockAccountCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="@state" Spinning="@unlockingAccount">
+            <VENFTApp_Blazor.Components.Spin Tip="@state" Spinning="@unlockingAccount">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         <span>Please Input password to unlock existing account</span>
@@ -62,7 +62,7 @@
                            Description="Wrong Password"
                            ShowIcon="true" />
                 }
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Coruzant/CoruzantNFT.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Coruzant/CoruzantNFT.razor
@@ -21,9 +21,9 @@
                         }
                         else
                         {
-                            <Spin Tip="Loading..." Style="min-width:50px;">
+                            <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                 <img src="@nft.ImageLink" style="max-height:200px;  max-width:250px;" />
-                            </Spin>
+                            </VENFTApp_Blazor.Components.Spin>
                         }
                         break;
                     case NFTTypes.CoruzantArticle:
@@ -33,9 +33,9 @@
                         }
                         else
                         {
-                            <Spin Tip="Loading..." Style="min-width:50px;">
+                            <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                 <img src="@nft.ImageLink" style="max-height:200px;  max-width:250px;" />
-                            </Spin>
+                            </VENFTApp_Blazor.Components.Spin>
                         }
                         break;
                     case NFTTypes.CoruzantPodcast:
@@ -58,9 +58,9 @@
                         }
                         else
                         {
-                            <Spin Tip="Loading..." Style="min-width:50px;">
+                            <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                 <img src="@nft.ImageLink" style="max-height:200px;  max-width:250px;" />
-                            </Spin>
+                            </VENFTApp_Blazor.Components.Spin>
                         }
                         break;
                 }

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Coruzant/CoruzantNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Coruzant/CoruzantNFTDetails.razor
@@ -10,7 +10,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin Tip="Loading..." Spinning="@loading">
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@loading">
             @if (!string.IsNullOrEmpty(NFT.NFTOriginTxId) && !string.IsNullOrEmpty(NFT.Utxo))
             {
                 <div style="position: absolute;right: 5px;top: -20px;">
@@ -36,13 +36,13 @@
                 }
                 else
                 {
-                    <Spin Tip="Loading..." Spinning="true">
+                    <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                         <div class="row" style="margin-top:10px;">
                             <div class="col d-flex justify-content-center align-items-center">
                                 <img src="@NFT.ImageLink" style="min-height:50px; max-height:100px; width:auto; min-width:50px; max-width:200px;" />
                             </div>
                         </div>
-                    </Spin>
+                    </VENFTApp_Blazor.Components.Spin>
                 }
                 @if (!string.IsNullOrEmpty(pnft.Nickname))
                 {
@@ -195,9 +195,9 @@
                                 }
                                 else
                                 {
-                                    <Spin Tip="Loading..." Spinning="true">
+                                    <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                                         <div style="width:100px; height:50px;"></div>
-                                    </Spin>
+                                    </VENFTApp_Blazor.Components.Spin>
                                 }
                             }
                         }
@@ -219,9 +219,9 @@
                             }
                             else
                             {
-                                <Spin Tip="Loading..." Spinning="true">
+                                <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                                     <div style="width:100px; height:50px;"></div>
-                                </Spin>
+                                </VENFTApp_Blazor.Components.Spin>
                             }
                         }
                     </a>
@@ -293,7 +293,7 @@
             {
                 <VENFTApp_Blazor.Components.NFTs.NFTHistory Utxo="@NFT.Utxo" NftType="@NFT.Type" />
             }
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 
     <VENFTApp_Blazor.Components.NFTs.Actions.SendNFT NFT="@NFT"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Coruzant/MintCoruzantNFTForm.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Coruzant/MintCoruzantNFTForm.razor
@@ -10,7 +10,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingMinting" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingMinting" Tip="Sending...">
             <div class="row">
                 <div class="col">
                     <div class="row" style="margin-top:10px;">
@@ -531,7 +531,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="Mint New NFT"
                Visible="@confirmVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/CreateTokenTransaction.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/CreateTokenTransaction.razor
@@ -4,7 +4,7 @@
 @using NBitcoin 
 @inject AppData AppData
 
-<Spin Tip="Creating..." Spinning="@creatingTransaction">
+<VENFTApp_Blazor.Components.Spin Tip="Creating..." Spinning="@creatingTransaction">
     <div class="row d-flex justify-content-center align-items-center">
         <div class="col" style="text-align: center;">
             <div class="row" style="width: 750px;">
@@ -184,7 +184,7 @@
             </div>
         </div>
     </div>
-</Spin>
+</VENFTApp_Blazor.Components.Spin>
 
 <!-- utxos list modal -->
 <Modal Title="Sender Utxos"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Doge/DogeTransactionDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Doge/DogeTransactionDetails.razor
@@ -7,7 +7,7 @@
 {
 <div class="row">
     <div class="col">
-        <Spin Tip="Loading..." Spinning="@txDetailsLoading">
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@txDetailsLoading">
             <div class="row">
                 <div class="col">
                     <div class="row">
@@ -80,7 +80,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 </div>
 }

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/LoadQRData.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/LoadQRData.razor
@@ -7,7 +7,7 @@
        OnOk="@showQRDialogCancel"
        Style="width:auto; max-width:300px;"
        OnCancel="@showQRDialogCancel">
-    <Spin Tip="@status" Spinning="@doneVisible">
+    <VENFTApp_Blazor.Components.Spin Tip="@status" Spinning="@doneVisible">
         <div class="row" style="margin-top:10px;">
             <div class="col d-flex justify-content-center align-items-center">
                 <div id="CameraStream"></div>
@@ -18,7 +18,7 @@
                 <VENFTApp_Blazor.Components.HelperButtons.CopyButton TextToCopy="@readedText" />
             </div>
         </div>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/DestroyNFTButton.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/DestroyNFTButton.razor
@@ -24,14 +24,14 @@ else
        Visible="@confirmDestroyVisible"
        OnOk="@HandleOk"
        OnCancel="@HandleCancel">
-    <Spin Tip="Removing the NFT... " Spinning="@removingNFT">
+    <VENFTApp_Blazor.Components.Spin Tip="Removing the NFT... " Spinning="@removingNFT">
         <p class="text-center">Do you really want to destroy this NFT?</p>
         <small class="text-center">When you destroy NFT the token will be connected to source tokens and it can be used for minting again.</small>
         @if (!string.IsNullOrEmpty(customMessage))
         {
             <p class="text-center">@customMessage</p>
         }
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/MoveNFTToSubAccount.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/MoveNFTToSubAccount.razor
@@ -9,7 +9,7 @@
        OnCancel="@sendNFTDialogCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Sending..." Spinning="@sendingTransaction">
+            <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
 
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
@@ -40,7 +40,7 @@
                         </Dropdown>
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/SendNFT.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/SendNFT.razor
@@ -9,7 +9,7 @@
        OnCancel="@sendNFTDialogCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Sending..." Spinning="@sendingTransaction">
+            <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         Fill Receiver Address:
@@ -20,7 +20,7 @@
                         <VENFTApp_Blazor.Components.Account.NeblioAddressInput AddressCheckedInputed="receiverAddressChangedHandler" />
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/SendNFTToDogeft.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Actions/SendNFTToDogeft.razor
@@ -9,7 +9,7 @@
        OnCancel="@sendNFTDialogCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Sending..." Spinning="@sendingTransaction">
+            <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         <img src="images/dogeft-logo.png" style="max-height:100px; max-width: 100px;" />
@@ -195,7 +195,7 @@
                         </div>
                     </div>
                 }
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/MintNFTDevice.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/MintNFTDevice.razor
@@ -8,7 +8,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingMinting" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingMinting" Tip="Sending...">
             <div class="row">
                 <div class="col">
 
@@ -347,7 +347,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="@(string.IsNullOrEmpty(NFT.Utxo)?"Mint New NFT":"Update NFT")"
                Visible="@confirmVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/MintNFTIoTDevice.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/MintNFTIoTDevice.razor
@@ -10,8 +10,8 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@loading" tip="Loading...">
-        <Spin spinning="@processingMinting" tip="Minting...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@loading" Tip="Loading...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingMinting" Tip="Minting...">
             <div class="row">
                 <div class="col">
 
@@ -472,8 +472,8 @@
                     }
                 </div>
             </div>
-        </Spin>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="@(string.IsNullOrEmpty(NFT.Utxo)?"Mint New NFT":"Update NFT")"
                Visible="@confirmVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTDeviceDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTDeviceDetails.razor
@@ -197,9 +197,9 @@
                     }
                     else if (string.IsNullOrEmpty(NFT.ImageLink) && !NFT.IsLoaded)
                     {
-                        <Spin Tip="Loading...">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...">
                             <NoImageLoaded />
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTDevicesList.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTDevicesList.razor
@@ -25,7 +25,7 @@
                 <div class="col h-100 d-flex justify-content-center align-items-center">
                     @if (NFTsList.Count == 0)
                     {
-                        <p><em><Spin Tip="Loading...No devices found yet" Style="min-width:100px;"></Spin></em></p>
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...No devices found yet" />
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTIoTDeviceDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTIoTDeviceDetails.razor
@@ -7,7 +7,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin Tip="Loading..." Spinning="@loading">
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@loading">
             @if (!string.IsNullOrEmpty(NFT.Utxo))
             {
                 <div style="position: absolute;right: 5px;top: -20px;">
@@ -297,9 +297,9 @@
                         }
                         else if (string.IsNullOrEmpty(NFT.ImageLink) && !NFT.IsLoaded)
                         {
-                            <Spin Tip="Loading...">
+                            <VENFTApp_Blazor.Components.Spin Tip="Loading...">
                                 <NoImageLoaded />
-                            </Spin>
+                            </VENFTApp_Blazor.Components.Spin>
                         }
                         else
                         {
@@ -336,7 +336,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTIoTDevicesList.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Devices/NFTIoTDevicesList.razor
@@ -25,7 +25,7 @@
                 <div class="col h-100 d-flex justify-content-center align-items-center">
                     @if (NFTsList.Count == 0)
                     {
-                        <p><em><Spin Tip="Loading...No devices found yet" Style="min-width:100px;"></Spin></em></p>
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...No devices found yet" />
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Images/ImageNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Images/ImageNFTDetails.razor
@@ -45,9 +45,9 @@
                     }
                     else if (string.IsNullOrEmpty(NFT.ImageLink) && !NFT.IsLoaded)
                     {
-                        <Spin Tip="Loading...">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...">
                             <NoImageLoaded />
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/MessageList.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/MessageList.razor
@@ -33,7 +33,7 @@
                 <div class="col h-100 d-flex justify-content-center align-items-center">
                     @if (NFTsList.Count == 0)
                     {
-                        <p><em><Spin Tip="Loading...No Messages found yet" Style="min-width:100px;"></Spin></em></p>
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...No Messages found yet" />
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/MessagingTabContent.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/MessagingTabContent.razor
@@ -56,7 +56,7 @@
                 <div class="col h-100 d-flex justify-content-center align-items-center">
                     @if (messageTab.NFTMessages.Count == 0)
                     {
-                        <p><em><Spin Tip="Loading...No Messages found yet" Style="min-width:100px;"></Spin></em></p>
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...No Messages found yet" />
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/NFTMessage.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/NFTMessage.razor
@@ -8,7 +8,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin Tip="Loading..." Spinning="@loading">
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@loading">
             <span class="badge badge-primary" style="position: absolute;right: 7px;top: 2px;">Conf: @(NeblioTransactionHelpers.IsEnoughConfirmationsForSend((int)NFT.TxDetails.Confirmations))</span>
 
             @if ((NFT as VEDriversLite.NFT.MessageNFT).IsReceivedMessage && !IsHistory)
@@ -103,9 +103,9 @@
                 {
                     <div class="row" style="margin-top:10px;">
                         <div class="col d-flex justify-content-center align-items-center">
-                            <Spin Tip="Downloading image..." Spinning="true">
+                            <VENFTApp_Blazor.Components.Spin Tip="Downloading image..." Spinning="true">
                                 <span>Downloading and encrypting Image. Please wait a while...</span>
-                            </Spin>
+                            </VENFTApp_Blazor.Components.Spin>
                         </div>
                     </div>
                 }
@@ -132,7 +132,7 @@
                     </div>
                 </div>
             }
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 
     <Modal Title="NFT Image"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/SendMessage.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Messages/SendMessage.razor
@@ -6,7 +6,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingSending" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingSending" Tip="Sending...">
             <div class="row">
                 <div class="col">
                     <div class="row" style="margin-top:10px;">
@@ -96,7 +96,7 @@
 
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="Mint New NFT"
                Visible="@confirmVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/MintNFTForm.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/MintNFTForm.razor
@@ -8,7 +8,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingMinting" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingMinting" Tip="Sending...">
             <div class="row">
                 <div class="col">
                     <div class="row" style="margin-top:10px;">
@@ -306,7 +306,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="@(string.IsNullOrEmpty(NFT.Utxo)?"Mint New NFT":"Update NFT")"
                Visible="@confirmVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Music/MusicNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Music/MusicNFTDetails.razor
@@ -40,9 +40,9 @@
                     }
                     else
                     {
-                        <Spin Tip="Loading..." Spinning="true">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                             <div style="width:100px; height:50px;"></div>
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                 </a>
             </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFT.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFT.razor
@@ -25,9 +25,9 @@
                             }
                             else if (string.IsNullOrEmpty(nft.ImageLink) && !nft.IsLoaded)
                             {
-                                <Spin Tip="Loading..." Style="min-width:50px;">
+                                <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                     <NoImageLoaded />
-                                </Spin>
+                                </VENFTApp_Blazor.Components.Spin>
                             }
                             else
                             {
@@ -41,9 +41,9 @@
                             }
                             else if (string.IsNullOrEmpty(nft.ImageLink) && !nft.IsLoaded)
                             {
-                                <Spin Tip="Loading..." Style="min-width:50px;">
+                                <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                     <NoImageLoaded />
-                                </Spin>
+                                </VENFTApp_Blazor.Components.Spin>
                             }
                             else
                             {
@@ -57,9 +57,9 @@
                             }
                             else if (string.IsNullOrEmpty(nft.ImageLink) && !nft.IsLoaded)
                             {
-                                <Spin Tip="Loading..." Style="min-width:50px;">
+                                <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                     <NoImageLoaded />
-                                </Spin>
+                                </VENFTApp_Blazor.Components.Spin>
                             }
                             else
                             {
@@ -73,9 +73,9 @@
                             }
                             else if (string.IsNullOrEmpty(nft.ImageLink) && !nft.IsLoaded)
                             {
-                                <Spin Tip="Loading..." Style="min-width:50px;">
+                                <VENFTApp_Blazor.Components.Spin Tip="Loading..." Style="min-width:50px;">
                                     <NoImageLoaded />
-                                </Spin>
+                                </VENFTApp_Blazor.Components.Spin>
                             }
                             else
                             {
@@ -145,9 +145,9 @@
                             }
                             else if (string.IsNullOrEmpty(nft.ImageLink) && !nft.IsLoaded)
                             {
-                                <Spin Tip="Loading...">
+                                <VENFTApp_Blazor.Components.Spin Tip="Loading...">
                                     <NoImageLoaded />
-                                </Spin>
+                                </VENFTApp_Blazor.Components.Spin>
                             }
                             else
                             {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFTDetails.razor
@@ -11,7 +11,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin Tip="Loading..." Spinning="@loading">
+        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@loading">
             @if (!string.IsNullOrEmpty(NFT.Utxo))
             {
                 <div style="position: absolute;right: 5px;top: -20px;">
@@ -145,7 +145,7 @@
                                                                 NFTSent="@NFTSentHandler" />
 
             <NFTHistory Utxo="@NFT.Utxo" NftType="@NFT.Type" />
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
     </div>
 
 </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFTHistory.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFTHistory.razor
@@ -17,7 +17,7 @@
         </div>
         <div class="row" style="margin-top:20px;">
             <div class="col d-flex justify-content-center align-items-center">
-                <Spin Tip="Loading History..." Spinning="@loadingNFTHistory">
+                <VENFTApp_Blazor.Components.Spin Tip="Loading History..." Spinning="@loadingNFTHistory">
                     @if (nftInDetailsHistory != null)
                     {
                         @if (nftInDetailsHistory.Count > 0)
@@ -146,7 +146,7 @@
                             <div style="min-width:100px; min-height:50px;">History Not Loaded</div>
                         }
                     }
-                </Spin>
+                </VENFTApp_Blazor.Components.Spin>
             </div>
         </div>
     </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFTList.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/NFTList.razor
@@ -159,13 +159,13 @@
        Visible="@destroyNFTsVisible"
        OnOk="@destroyNFTsConfirm"
        OnCancel="@destroyNFTsCancel">
-    <Spin Spinning="@destroyingNFTs" Tip="Destroying NFTs...">
+    <VENFTApp_Blazor.Components.Spin Spinning="@destroyingNFTs" Tip="Destroying NFTs...">
         <div class="row">
             <div class="col d-flex justify-content-center align-items-center">
                 <span>Do you really want to destroy selected NFTs? All will be returned back to you address as source tokens.</span>
             </div>
         </div>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ApproveOrder.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ApproveOrder.razor
@@ -30,9 +30,9 @@
        Visible="@showApproveOrderVisible"
        OnOk="@ApproveOrderConfirm"
        OnCancel="@ApproveOrderCancel">
-    <Spin Tip="Writing Approve state..." Spinning="@loading">
+    <VENFTApp_Blazor.Components.Spin Tip="Writing Approve state..." Spinning="@loading">
         <span class="text-center">Do you really want to approve this order?</span>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ReturnNFTPayment.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ReturnNFTPayment.razor
@@ -4,18 +4,18 @@
 @inject AppData AppData
 @inject IJSRuntime JSRuntime
 
-<Spin Tip="Sending..." Spinning="@sendingTransaction">
+<VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
     <button class="btn btn-primary" @onclick="ShowSendNFTDialog" style="width: 40px;height: 25px;padding-left: 0px;padding-right: 0px;padding-top: 0px;padding-bottom: 0px;font-size: 12px;">
         <i class="oi oi-location" style="font-size:12px;"></i>
     </button>
-</Spin>
+</VENFTApp_Blazor.Components.Spin>
 <Modal Title="Return NFT Payment"
        Visible="@sendNFTDialogVisible"
        OnOk="@sendNFTDialogOK"
        OnCancel="@sendNFTDialogCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Sending..." Spinning="@sendingTransaction">
+            <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         Returning payment was send from @receiverAddress
@@ -31,7 +31,7 @@
                         Amount to return: @Price NEBL <img style="width: 12px;margin-left: 4px; margin-bottom:2px;" src="images/neblio-icon.png" />
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/SendNFTPayment.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/SendNFTPayment.razor
@@ -4,18 +4,18 @@
 @inject AppData AppData
 @inject IJSRuntime JSRuntime
 
-<Spin Tip="Sending..." Spinning="@sendingTransaction">
+<VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
     <button class="btn btn-primary" @onclick="ShowSendNFTDialog" style="width: 40px;height: 25px;padding-left: 0px;padding-right: 0px;padding-top: 0px;padding-bottom: 0px;font-size: 12px;">
         <i class="oi oi-dollar" style="font-size:12px;"></i>
     </button>
-</Spin>
+</VENFTApp_Blazor.Components.Spin>
 <Modal Title="Buy this NFT"
        Visible="@sendNFTDialogVisible"
        OnOk="@sendNFTDialogOK"
        OnCancel="@sendNFTDialogCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Sending..." Spinning="@sendingTransaction">
+            <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         This dialog will process the order and payment of this NFT
@@ -31,7 +31,7 @@
                         Price @Price NEBL <img style="width: 12px; height:12px; margin-left: 4px; margin-bottom:2px;" src="images/neblio-icon.png" />
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/SetNFTPrice.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/SetNFTPrice.razor
@@ -9,7 +9,7 @@
        OnCancel="@setPriceNFTDialogCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Sending..." Spinning="@sendingTransaction">
+            <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
                 <div class="row" style="margin-top:20px;">
 
                     <div class="col d-flex justify-content-center align-items-center">
@@ -64,7 +64,7 @@
                     </div>
                 </div>
                 }-->
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ShowNFTOrderOnInvoiceDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ShowNFTOrderOnInvoiceDetails.razor
@@ -17,7 +17,7 @@
        Visible="@showOrderNFTDialogVisible"
        OnCancel="@NFTDetailsClose"
        Footer="null">
-    <Spin Tip="Loading Product Data..." Spinning="@showOrderNFTDialogLoading">
+    <VENFTApp_Blazor.Components.Spin Tip="Loading Product Data..." Spinning="@showOrderNFTDialogLoading">
         @if (!string.IsNullOrEmpty(NFT.Utxo))
         {
             <div class="row" style="margin-top:20px;">
@@ -30,7 +30,7 @@
         {
             <div style="min-width:100px; min-height:50px;"></div>
         }
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ShowNFTProductOnInvoiceDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Payments/ShowNFTProductOnInvoiceDetails.razor
@@ -17,7 +17,7 @@
        Visible="@showProductNFTDialogVisible"
        OnCancel="@NFTDetailsClose"
        Footer="null">
-    <Spin Tip="Loading Product Data..." Spinning="@showProductNFTDialogLoading">
+    <VENFTApp_Blazor.Components.Spin Tip="Loading Product Data..." Spinning="@showProductNFTDialogLoading">
         @if (!string.IsNullOrEmpty(NFT.Utxo))
         {
             <div class="row" style="margin-top:20px;">
@@ -30,7 +30,7 @@
         {
             <div style="min-width:100px; min-height:50px;"></div>
         }
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Posts/PostNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Posts/PostNFTDetails.razor
@@ -59,9 +59,9 @@
                     }
                     else if (string.IsNullOrEmpty(NFT.ImageLink) && !NFT.IsLoaded)
                     {
-                        <Spin Tip="Loading...">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...">
                             <NoImageLoaded />
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Products/ProductNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Products/ProductNFTDetails.razor
@@ -58,9 +58,9 @@
                     }
                     else if (string.IsNullOrEmpty(NFT.ImageLink) && !NFT.IsLoaded)
                     {
-                        <Spin Tip="Loading...">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading...">
                             <NoImageLoaded />
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                     else
                     {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Profile.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Profile.razor
@@ -7,7 +7,7 @@
 @inject AppData AppData
 @inject HttpClient _client
 
-<Spin spinning="@loadingProfile" tip="Loading Profile...">
+<VENFTApp_Blazor.Components.Spin Spinning="@loadingProfile" Tip="Loading Profile...">
     <div class="row d-flex justify-content-center" style="min-width:250px;">
         <div class="col">
             <div class="row">
@@ -67,7 +67,7 @@
             }
         </div>
     </div>
-</Spin>
+</VENFTApp_Blazor.Components.Spin>
 
 <Modal Title="Create new profile NFT"
        Visible="@createNewProfileVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Profiles/ProfileNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Profiles/ProfileNFTDetails.razor
@@ -75,9 +75,9 @@
                     }
                     else
                     {
-                        <Spin Tip="Loading..." Spinning="true">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                             <img src="@NFT.ImageLink" style="min-height:100px; max-height:150px; width:auto; min-width:50px; max-width:250px;" />
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                 </a>
             </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/EventNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/EventNFTDetails.razor
@@ -109,9 +109,9 @@
                     }
                     else
                     {
-                        <Spin Tip="Loading..." Spinning="true">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                             <div style="width:100px; height:50px;"></div>
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                 </a>
             </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/MintEventAndTickets.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/MintEventAndTickets.razor
@@ -8,7 +8,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingMinting" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingMinting" Tip="Sending...">
             <div class="row">
                 <div class="col">
                     @if (nftType == NFTTypes.Ticket)
@@ -459,7 +459,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="@(string.IsNullOrEmpty(NFT.Utxo)?"Mint New NFT":"Update NFT")"
                Visible="@confirmVisible"
@@ -500,7 +500,7 @@
                Visible="@eventNFTDetailsVisible"
                OnCancel="@eventNFTDetailsClose"
                Footer="null">
-            <Spin Tip="Loading Event Data..." Spinning="@loadingEventData">
+            <VENFTApp_Blazor.Components.Spin Tip="Loading Event Data..." Spinning="@loadingEventData">
                 @if (!string.IsNullOrEmpty(loadedEventNFT.Utxo))
                 {
                     <div class="row" style="margin-top:20px;">
@@ -518,7 +518,7 @@
                 {
                     <div style="min-width:100px; min-height:50px;"></div>
                 }
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </Modal>
     </div>
 </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/ShowNFTEvent.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/ShowNFTEvent.razor
@@ -17,7 +17,7 @@
        Visible="@showEventNFTDialogVisible"
        OnCancel="@eventNFTDetailsClose"
        Footer="null">
-    <Spin Tip="Loading Event Data..." Spinning="@showEventNFTDialogLoading">
+    <VENFTApp_Blazor.Components.Spin Tip="Loading Event Data..." Spinning="@showEventNFTDialogLoading">
         @if (!string.IsNullOrEmpty(NFT.Utxo))
         {
             <div class="row" style="margin-top:20px;">
@@ -30,7 +30,7 @@
         {
             <div style="min-width:100px; min-height:50px;"></div>
         }
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/TicketNFTDetails.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/TicketNFTDetails.razor
@@ -137,9 +137,9 @@
                     }
                     else
                     {
-                        <Spin Tip="Loading..." Spinning="true">
+                        <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="true">
                             <div style="width:100px; height:50px;"></div>
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     }
                 </a>
             </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/UseTicket.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Tickets/UseTicket.razor
@@ -29,9 +29,9 @@
        Visible="@showUseTicketVisible"
        OnOk="@UseTicketConfirm"
        OnCancel="@UseTicketCancel">
-    <Spin Tip="Writing Use state..." Spinning="@loading">
+    <VENFTApp_Blazor.Components.Spin Tip="Writing Use state..." Spinning="@loading">
         <span class="text-center">Do you really want to use this ticket?</span>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Verification/NFTOwnerVerifier.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Verification/NFTOwnerVerifier.razor
@@ -33,7 +33,7 @@
                             </small>
                         </div>
                         </div>
-                        <Spin Tip="Processing..." Spinning="@processing">
+                        <VENFTApp_Blazor.Components.Spin Tip="Processing..." Spinning="@processing">
                             <div class="row" style="margin-top:10px;">
                                 <div class="col d-flex justify-content-center align-items-center">
                                     <button @onclick=ReadCode>Verify</button>
@@ -89,7 +89,7 @@
                                     }
                                 </div>
                             </div>
-                        </Spin>
+                        </VENFTApp_Blazor.Components.Spin>
                     </div>
                 </div>
             </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Verification/OwnershipQRCode.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/NFTs/Verification/OwnershipQRCode.razor
@@ -18,7 +18,7 @@
        Style="width:auto; max-width:300px;"
        OnCancel="@showOwnershipDialogCancel"
        Footer="null">
-    <Spin Tip="@creatingOwnerQRCodeState" Spinning="@showOwnershipDialogLoading">
+    <VENFTApp_Blazor.Components.Spin Tip="@creatingOwnerQRCodeState" Spinning="@showOwnershipDialogLoading">
         <div class="row">
             <div class="col d-flex justify-content-center align-items-center">
                 <span class="text-center">Code is valid for: @qrCodeRefreshCounter s</span>
@@ -40,7 +40,7 @@
             </div>
         </div>
         <VENFTApp_Blazor.Components.HelperButtons.CopyButton TextToCopy="@ownershipCodeSerialized" />
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/OpenedTabList.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/OpenedTabList.razor
@@ -10,7 +10,7 @@
        OnOk="@showBrowseTabsCancel"
        Style="width:auto; max-width:600px;"
        OnCancel="@showBrowseTabsCancel">
-    <Spin Tip="@status" Spinning="@statusVisible">
+    <VENFTApp_Blazor.Components.Spin Tip="@status" Spinning="@statusVisible">
         <div class="row d-flex justify-content-center align-items-center">
             <div class="col">
                 <div class="row" style="margin-top:10px;">
@@ -43,7 +43,7 @@
                 </div>
             </div>
         </div>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 <Modal Title="Open Tab"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/Spin.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/Spin.razor
@@ -1,0 +1,28 @@
+﻿<div class="position-relative w-100 h-100" style="@Style">
+    <div class="@(Spinning ? "opacity-25 pe-none" : "")">
+        @ChildContent
+    </div>
+    @if (Spinning)
+    {
+        <div class="spin-overlay text-primary">
+            <div class="spinner-border flex-shrink-0" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+            @if (!String.IsNullOrEmpty(Tip))
+            {
+                <div class="spin-tip">@Tip</div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Spinning { get; set; } = true;
+    [Parameter]
+    public string Tip { get; set; }
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+    [Parameter]
+    public String Style { get; set; }
+}

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/TabThumbnail.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/TabThumbnail.razor
@@ -12,9 +12,9 @@
                 }
                 else
                 {
-                    <Spin Tip="Loading..." Spinning="@tryToLoad">
+                    <VENFTApp_Blazor.Components.Spin Tip="Loading..." Spinning="@tryToLoad">
                         <img class="card-img-top w-auto" src="@ImageLink" style="min-height:50px; max-height:70px; max-width:150px; min-width:50px;" />
-                    </Spin>
+                    </VENFTApp_Blazor.Components.Spin>
                 }
             </div>
         </div>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/TransactionBuilder.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/TransactionBuilder.razor
@@ -24,7 +24,7 @@
                ShowIcon="true" />
     }
 
-    <Spin spinning="@sendingTransaction" tip="Sending Transaction...">
+    <VENFTApp_Blazor.Components.Spin Spinning="@sendingTransaction" Tip="Sending Transaction...">
 
         <div class="row">
             <div class="col">
@@ -255,7 +255,7 @@
                 </div>
             </div>
         </div>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 
     <!-- add token tx -->
     <Modal Title="Add Token Tx"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/UploadImage.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/UploadImage.razor
@@ -12,7 +12,7 @@
         <!--<div class="row" id="ipfsImageUpload" style="margin-top:20px;">-->
         <div class="row" style="margin-top:20px;">
             <div class="col">
-                <Spin spinning="@uploadingImage" tip="Uploading to IPFS...">
+                <VENFTApp_Blazor.Components.Spin Spinning="@uploadingImage" Tip="Uploading to IPFS...">
 
                     <div class="row">
                         <div class="col d-flex justify-content-center align-items-center">
@@ -60,7 +60,7 @@
                         </div>
                     </div>
 
-                </Spin>
+                </VENFTApp_Blazor.Components.Spin>
             </div>
         </div>
         <div class="row" style="margin-top:20px;">
@@ -95,7 +95,7 @@
                         <p>No image loaded</p>
                         break;
                     case LoadingImageStages.Loading:
-                        <Spin Tip="Reloading..." />
+                        <VENFTApp_Blazor.Components.Spin Tip="Reloading..." />
                         break;
                     case LoadingImageStages.Loaded:
                         @if (NFTType == NFTTypes.Image || NFTType == NFTTypes.Post || NFTType == NFTTypes.Profile || NFTType == NFTTypes.CoruzantArticle || NFTType == NFTTypes.CoruzantProfile || NFTType == NFTTypes.CoruzantPodcast)

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceAddProduct.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceAddProduct.razor
@@ -10,7 +10,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingSending" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingSending" Tip="Sending...">
             <div class="row">
                 <div class="col">
 
@@ -48,7 +48,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="Add product to WooCommerce Shop"
                Visible="@confirmVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceAddProductButton.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceAddProductButton.razor
@@ -46,16 +46,16 @@
        Visible="@withoutPriceVisible"
        OnOk="@withoutPriceConfirm"
        OnCancel="@withoutPriceCancel">
-    <Spin spinning="@processingSending" tip="Sending...">
+    <VENFTApp_Blazor.Components.Spin Spinning="@processingSending" Tip="Sending...">
         <p>This product does not have setted the price. Do you want to continue?</p>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 <Modal Title="Add product to WooCommerce Shop"
        Visible="@confirmVisible"
        OnOk="@HandleOk"
        OnCancel="@HandleCancel">
-    <Spin spinning="@processingSending" tip="Sending...">
+    <VENFTApp_Blazor.Components.Spin Spinning="@processingSending" Tip="Sending...">
         <div class="row d-flex justify-content-center align-items-center">
             <div class="col">
                 <span style="font-size: 12px;">Do you really want to upload this product to your store?</span>
@@ -184,7 +184,7 @@
                 </div>
             </div>
         }
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </Modal>
 
 <Modal Title="NFT Details"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceConnection.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceConnection.razor
@@ -10,7 +10,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingSending" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingSending" Tip="Sending...">
             <div class="row">
                 <div class="col">
                     <div class="row" style="margin-top:10px;">
@@ -193,7 +193,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="Woo Commerce Product"
                Visible="@showWooComProductVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceProduct.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Components/WooCommerce/WooCommerceProduct.razor
@@ -10,7 +10,7 @@
 
 <div class="row">
     <div class="col">
-        <Spin spinning="@processingSending" tip="Sending...">
+        <VENFTApp_Blazor.Components.Spin Spinning="@processingSending" Tip="Sending...">
             <div class="row">
                 <div class="col">
                     @if (WooCommerceHelpers.IsInitialized)
@@ -130,7 +130,7 @@
                     }
                 </div>
             </div>
-        </Spin>
+        </VENFTApp_Blazor.Components.Spin>
 
         <Modal Title="NFT Details"
                Visible="@showNFTDetailsVisible"

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Advanced.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Advanced.razor
@@ -17,7 +17,7 @@
 @page "/advanced"
 
 <div class="container-fluid overflow-auto">
-    <Spin Tip="Sending..." Spinning="@sending">
+    <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sending">
         <div class="row">
             <div class="col">
 
@@ -200,7 +200,7 @@
                                     <h5 class="text-center">VENFT Airdrop</h5>
                                 </div>
                                 <div class="card-body w-100">
-                                    <Spin Tip="Sending..." Spinning="@sendingTransaction">
+                                    <VENFTApp_Blazor.Components.Spin Tip="Sending..." Spinning="@sendingTransaction">
                                         <div class="row" style="margin-top:30px; min-width:250px;">
                                             <div class="col w-100">
                                                 <div class="row" style="margin-top:10px;">
@@ -220,7 +220,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                    </Spin>
+                                    </VENFTApp_Blazor.Components.Spin>
                                 </div>
                             </div>
 
@@ -230,7 +230,7 @@
             </div>
         </div>
         <VENFTApp_Blazor.Components.InfoEventModal />
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
 </div>
 
 @code {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Browser.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Browser.razor
@@ -10,7 +10,7 @@
 @inject IJSRuntime JSRuntime
 @page "/browser"
 
-<Spin Tip="Loading Browser..." Spinning="@loadingBrowser">
+<VENFTApp_Blazor.Components.Spin Tip="Loading Browser..." Spinning="@loadingBrowser">
     <div class="container-fluid overflow-auto">
         <div class="row">
             <div class="col d-flex justify-content-center align-items-center">
@@ -88,7 +88,7 @@
 
                     <div class="tab-content" id="shopTabsContent">
                                 <div role="tabpanel" class="tab-pane active" style="min-height: 200px;">
-                                    <Spin Spinning="@tabIsLoading" Tip="Tab Content is Loading...">
+                                    <VENFTApp_Blazor.Components.Spin Spinning="@tabIsLoading" Tip="Tab Content is Loading...">
                                     <div class="row">
                                         <div class="col">
                                             <div class="row" style="margin-top: 10px;">
@@ -163,7 +163,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    </Spin>
+                                    </VENFTApp_Blazor.Components.Spin>
                                 </div>
                     </div>
                 </div>
@@ -171,7 +171,7 @@
         </div>
         <VENFTApp_Blazor.Components.InfoEventModal />
     </div>
-</Spin>
+</VENFTApp_Blazor.Components.Spin>
 
 <!--Open New Tab Modal-->
 <Modal Title="Open Tab"
@@ -237,7 +237,7 @@
 
             @if (AppData.VENFTOwners.Count == 0)
             {
-                <p><Spin Tip="Loading..."></Spin></p>
+                <p><VENFTApp_Blazor.Components.Spin Tip="Loading..."></VENFTApp_Blazor.Components.Spin></p>
             }
             else
             {

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/BuyNFT.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/BuyNFT.razor
@@ -34,7 +34,7 @@
 
     <div class="row" style="margin-bottom:20px;">
         <div class="col">
-            <Spin spinning="@sendingTransaction" tip="Sending Transaction...">
+            <VENFTApp_Blazor.Components.Spin Spinning="@sendingTransaction" Tip="Sending Transaction...">
                 <div class="card" style="margin-top:10px;">
                     <div class="card-header" style="padding-top: 5px;padding-bottom: 5px;">
                         @if (currecncy == Currecncy.NBL && !string.IsNullOrEmpty(AppData.Account.Address))
@@ -202,7 +202,7 @@
                         </div>
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 
@@ -215,7 +215,7 @@
        OnCancel="@UnclockAccountCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Unlocking..." Spinning="@unlockingAccount">
+            <VENFTApp_Blazor.Components.Spin Tip="Unlocking..." Spinning="@unlockingAccount">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         <span>Please Input password</span>
@@ -241,7 +241,7 @@
                            Description="Wrong Password."
                            ShowIcon="true" />
                 }
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/DogeAccount.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/DogeAccount.razor
@@ -25,7 +25,7 @@
 
     <div class="row" style="margin-bottom:20px;">
         <div class="col">
-            <Spin spinning="@sendingTransaction" tip="Sending Transaction...">
+            <VENFTApp_Blazor.Components.Spin Spinning="@sendingTransaction" Tip="Sending Transaction...">
                 <div class="card" style="margin-top:10px;">
                     <div class="card-header" style="padding-top: 5px;padding-bottom: 5px;">
                         <h5 class="text-center">Send Doge Transaction</h5>
@@ -91,7 +91,7 @@
                         </div>
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Index.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Index.razor
@@ -10,7 +10,7 @@
 @page "/"
 
 <div class="container-fluid overflow-auto">
-    <Spin spinning="@creatingAddressSpinner" tip="Creating Address...">
+    <VENFTApp_Blazor.Components.Spin Spinning="@creatingAddressSpinner" Tip="Creating Address...">
         <div class="row">
             <div class="col">
                 <div class="row">
@@ -61,7 +61,7 @@
 
         <VENFTApp_Blazor.Components.Account.UnlockAccount Visible="@unlockAcocuntModalVisible" AccountUnlocked="AccountUnlocked" />
 
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
     <VENFTApp_Blazor.Components.InfoEventModal />
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Messages.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Messages.razor
@@ -11,7 +11,7 @@
 @page "/messages"
 
 <div class="container-fluid h-100 w-100 overflow-auto" style="padding:2px;">
-    <Spin Tip="Loading Message Browser..." Spinning="@loadingBrowser">
+    <VENFTApp_Blazor.Components.Spin Tip="Loading Message Browser..." Spinning="@loadingBrowser">
         <div class="row h-100 w-100" style="margin-left:0px; padding:5px;">
             <div class="col h-100 w-100" style="margin-left:0px; padding:0px;">
                 <div class="row">
@@ -67,7 +67,7 @@
 
             </div>
         </div>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
     <VENFTApp_Blazor.Components.InfoEventModal />
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/MintNFT.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/MintNFT.razor
@@ -222,7 +222,7 @@
            OnCancel="@orderSourceTokensCancel">
         <div class="row" style="margin-top:10px;">
             <div class="col d-flex justify-content-center align-items-center">
-                <Spin Tip="Processing the Order..." Spinning="@orderingTokens">
+                <VENFTApp_Blazor.Components.Spin Tip="Processing the Order..." Spinning="@orderingTokens">
                     <div class="row" style="margin-top:20px;">
                         <div class="col d-flex justify-content-center align-items-center">
                             <p>Do you want to buy 100 VENFT tokens? It costs 1 NEBL.</p>
@@ -245,7 +245,7 @@
                             <p>Order TxId: @orderTxId</p>
                         </div>
                     </div>
-                </Spin>
+                </VENFTApp_Blazor.Components.Spin>
             </div>
         </div>
     </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/NFTExplorer.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/NFTExplorer.razor
@@ -12,7 +12,7 @@
 @page "/nftexplorer"
 
 <div class="container-fluid h-100 w-100 overflow-auto">
-    <Spin Tip="Loading NFT Explorer..." Spinning="@loadingBrowser">
+    <VENFTApp_Blazor.Components.Spin Tip="Loading NFT Explorer..." Spinning="@loadingBrowser">
         <div class="row h-100 w-100">
             <div class="col h-100 w-100">
                 <div class="row">
@@ -118,7 +118,7 @@
                 </div>
             </div>
         </div>
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
     <VENFTApp_Blazor.Components.InfoEventModal />
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Payment.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Payment.razor
@@ -32,7 +32,7 @@
 
     <div class="row" style="margin-bottom:20px;">
         <div class="col">
-            <Spin spinning="@sendingTransaction" tip="Sending Transaction...">
+            <VENFTApp_Blazor.Components.Spin Spinning="@sendingTransaction" Tip="Sending Transaction...">
                 <div class="card" style="margin-top:10px;">
                     <div class="card-header" style="padding-top: 5px;padding-bottom: 5px;">
                         @if (currecncy == Currecncy.NBL && !string.IsNullOrEmpty(AppData.Account.Address))
@@ -168,7 +168,7 @@
                         </div>
                     </div>
                 </div>
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 
@@ -181,7 +181,7 @@
        OnCancel="@UnclockAccountCancel">
     <div class="row">
         <div class="col">
-            <Spin Tip="Unlocking..." Spinning="@unlockingAccount">
+            <VENFTApp_Blazor.Components.Spin Tip="Unlocking..." Spinning="@unlockingAccount">
                 <div class="row">
                     <div class="col d-flex justify-content-center align-items-center">
                         <span>Please Input password</span>
@@ -207,7 +207,7 @@
                            Description="Wrong Password."
                            ShowIcon="true" />
                 }
-            </Spin>
+            </VENFTApp_Blazor.Components.Spin>
         </div>
     </div>
 </Modal>

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Send.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Pages/Send.razor
@@ -13,7 +13,7 @@
 
 <div class="container-fluid overflow-auto">
 
-    <Spin spinning="@sendingTransaction" tip="Sending Transaction...">
+    <VENFTApp_Blazor.Components.Spin Spinning="@sendingTransaction" Tip="Sending Transaction...">
         <div class="row">
             <div class="col">
                 <div class="row">
@@ -525,7 +525,7 @@
             </div>
         </div>
 
-    </Spin>
+    </VENFTApp_Blazor.Components.Spin>
     <VENFTApp_Blazor.Components.InfoEventModal />
 </div>
 

--- a/VirtualEconomyFramework/VENFTApp-Blazor/wwwroot/css/app.css
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/wwwroot/css/app.css
@@ -131,6 +131,30 @@ app {
     color: red;
 }
 
+.opacity-25 {
+    opacity: 0.25;
+}
+
+.pe-none {
+    pointer-events: none;
+}
+
+.spin-overlay {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    position: absolute;
+    inset: 0;
+    max-height: 400px;
+}
+
+.spin-tip {
+    font-style: italic;
+    text-shadow: 0 1px 2px #fff;
+}
+
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;


### PR DESCRIPTION
There are a lot of AntDesign components. For each, I will create separted PR.
Note that I need to use name with namespace until we remove AntDesign completely, so there are several changes.

Design of spinner is based on bootstrap. We can change it easily.
Here is how it looks like:

![spin-old-new](https://user-images.githubusercontent.com/72392311/154047882-894ad3e5-c2c0-4627-9ccf-01085b8c898f.png)