### PR TITLE
Adding back cache to blockheight calculation logic.

### DIFF
--- a/VirtualEconomyFramework/VEDrivers/VEDrivers.csproj
+++ b/VirtualEconomyFramework/VEDrivers/VEDrivers.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />

--- a/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionHelpers.cs
+++ b/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionHelpers.cs
@@ -627,8 +627,7 @@ namespace VEDriversLite
                         break;
                     }
                 }
-            }                       
-
+            }
             return await SignAndBroadcast(transaction, key, addressForTx);
         }
 
@@ -2411,7 +2410,7 @@ namespace VEDriversLite
         /// <param name="requiredAmount">amount what must be collected even by multiple utxos</param>
         /// <returns></returns>
         public static async Task<ICollection<Utxos>> GetAddressNeblUtxo(string addr, double minAmount = 0.0001, double requiredAmount = 0.0001)
-        {
+        {       
             GetAddressInfoResponse addinfo = null;
             var resp = new List<Utxos>();
 
@@ -2425,7 +2424,7 @@ namespace VEDriversLite
             utxos = utxos.OrderByDescending(u => u.Value).ToList();
 
             var founded = 0.0;
-            double latestBlockHeight = await NeblioTransactionsCache.LatestBlockHeight(utxos.FirstOrDefault()?.Txid);
+            double latestBlockHeight = await NeblioTransactionsCache.LatestBlockHeight(utxos.FirstOrDefault()?.Txid, addr);
             foreach (var ut in utxos.Where(u => u.Blockheight > 0 && u.Value > 10000 && u.Tokens?.Count == 0 && ((double)u.Value) > (minAmount * FromSatToMainRatio)))
             {
                 double UtxoBlockHeight = ut.Blockheight != null ? ut.Blockheight.Value : 0;
@@ -2441,6 +2440,7 @@ namespace VEDriversLite
             }
 
             return new List<Utxos>();
+            
         }
 
         private static bool IsValidUtxo(double UtxoBlockHeight, double latestBlockCount)
@@ -2471,7 +2471,7 @@ namespace VEDriversLite
                 return 0;
             }
 
-            double latestBlockHeight = await NeblioTransactionsCache.LatestBlockHeight(utxos.FirstOrDefault()?.Txid);
+            double latestBlockHeight = await NeblioTransactionsCache.LatestBlockHeight(utxos.FirstOrDefault()?.Txid, address);
             foreach (var ut in uts.Where(u => u.Blockheight > 0 && u.Tokens != null && u.Tokens.Count > 0))
             {
                 var toks = ut.Tokens.ToArray();
@@ -2509,7 +2509,7 @@ namespace VEDriversLite
             }
 
             utxos = utxos.OrderByDescending(u => u.Value).ToList();
-            double latestBlockHeight = await NeblioTransactionsCache.LatestBlockHeight(utxos.FirstOrDefault()?.Txid);
+            double latestBlockHeight = await NeblioTransactionsCache.LatestBlockHeight(utxos.FirstOrDefault()?.Txid, addr);
 
             foreach (var ut in utxos.Where(u => u.Blockheight > 0 && u.Tokens.Count > 0))
             {

--- a/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionsCache.cs
+++ b/VirtualEconomyFramework/VEDriversLite/Neblio/NeblioTransactionsCache.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Runtime.Caching;
-using System.Timers;
-using VEDriversLite.NeblioAPI;
+using Microsoft.Extensions.Caching.Memory;
 using System.Threading.Tasks;
 
 namespace VEDriversLite.Neblio
@@ -14,30 +10,56 @@ namespace VEDriversLite.Neblio
     /// </summary>
     public static class NeblioTransactionsCache
     {
-        private static readonly object _lockObject = new object();
-        private static double latestblock = 0.0;
-        private static DateTime time = DateTime.MinValue;
-        private static TimeSpan timeSpanToRefresh = new TimeSpan(0,0,5);
+        static readonly MemoryCache cache = new MemoryCache(new MemoryCacheOptions());
         /// <summary>
         /// Method will check if the data for current address is available in cache and returns the blockheight, IF not avaialble then retrievs from API.
         /// </summary>
         /// <param name="address">The address for which we need the latest block height</param>
         /// <returns></returns>
-        public static async Task<double> LatestBlockHeight(string utxo)
+        public async static Task<double> LatestBlockHeight(string utxo, string address)
         {
-            var newtime = DateTime.UtcNow;
-            if ((newtime - time) >= timeSpanToRefresh)
+            double blockHeightValue = 0;
+
+            object value = GetCacheValue(address);
+
+            if (value != default)
+            {
+                blockHeightValue = (double)value;
+            }
+            else
             {
                 var data = await NeblioTransactionHelpers.GetClient().GetTransactionInfoAsync(utxo);
-                time = newtime;
+
                 if (data != null && data.Blockheight != null && data.Confirmations != null)
                 {
-                    latestblock = data.Blockheight.Value + data.Confirmations.Value;
-                }                
+                    blockHeightValue = data.Blockheight.Value + data.Confirmations.Value;
+                }
+                SetChacheValue(address, blockHeightValue);
             }
+            return blockHeightValue;
+        }
 
-            return latestblock;
+        private static object GetCacheValue(string key)
+        {
+            if (key != null && cache.TryGetValue(key, out object val))
+            {
+                return val;
+            }
+            else
+            {
+                return default;
+            }
+        }
 
+        public static void SetChacheValue(string key, object value)
+        {
+            if (key != null)
+            {
+                cache.Set(key, value, new MemoryCacheEntryOptions
+                {
+                    SlidingExpiration = TimeSpan.FromSeconds(10)
+                });
+            }
         }
     }
 }

--- a/VirtualEconomyFramework/VEDriversLite/VEDriversLite.csproj
+++ b/VirtualEconomyFramework/VEDriversLite/VEDriversLite.csproj
@@ -32,11 +32,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Ipfs.Http.Client" Version="0.33.0" />
     <PackageReference Include="NBitcoin" Version="5.0.81" />
     <PackageReference Include="NBitcoin.Altcoins" Version="2.0.33" />
-    <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
     <PackageReference Include="WordPressPCL" Version="1.9.0" />
     <!--<PackageReference Include="QRCoder" Version="1.4.1" />-->
     <!--<PackageReference Include="ZXing.Net" Version="0.16.6" />-->

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/CheckSpendableNeblioTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/CheckSpendableNeblioTest.cs
@@ -22,7 +22,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning an error result if an address is not having enough Neblio.
         /// </summary>
         [Fact]
-        public void CheckSpendableNeblio_InCorrect_Test()
+        public async void CheckSpendableNeblio_InCorrect_Test()
         {
             var count = 2;
             this.Address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWd";
@@ -30,7 +30,7 @@ namespace VEFrameworkUnitTest.Neblio
             var getAddressInfoResponse = new GetAddressInfoResponse();
             _client.Setup(x => x.GetAddressInfoAsync(It.IsAny<string>())).ReturnsAsync(getAddressInfoResponse);           
 
-            var result = this.CheckSpendableNeblio(0.23).Result;
+            var result = await this.CheckSpendableNeblio(0.23);
 
             string error = "You dont have Neblio on the address. Probably waiting for more than " + count +
                            " confirmations.";
@@ -43,7 +43,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning Utxos if an address has spendable Neblios.
         /// </summary>
         [Fact]
-        public void CheckSpendableNeblio_Valid_Test()
+        public async void CheckSpendableNeblio_Valid_Test()
         {            
             this.Address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh";
 
@@ -129,7 +129,7 @@ namespace VEFrameworkUnitTest.Neblio
             
             _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);            
 
-            var result1 = CheckSpendableNeblio(0.0009).Result;
+            var result1 = await CheckSpendableNeblio(0.0009);
 
             const string ok = "OK";
             Assert.Equal(ok, result1.Item1);

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetAddressNeblUtxoTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetAddressNeblUtxoTest.cs
@@ -21,7 +21,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning Utxos for a valid address and required amount is found.
         /// </summary>
         [Fact]
-        public void GetAddressNeblUtxo_Valid_Test()
+        public async void GetAddressNeblUtxo_Valid_Test()
         {
             #region TransactionObject
 
@@ -101,15 +101,15 @@ namespace VEFrameworkUnitTest.Neblio
 
             //Arrange           
             string address = "123";
-            double amount = 0.009;            
+            double amount = 0.009;
 
-            GetAddressInfoResponse addressObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetAddressInfoResponse>(response);                                          
+            GetAddressInfoResponse addressObject = Newtonsoft.Json.JsonConvert.DeserializeObject<GetAddressInfoResponse>(response);
 
             _client.Setup(x => x.GetAddressInfoAsync(It.IsAny<string>())).ReturnsAsync(addressObject);
-            _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);                                    
+            _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);
 
             //ACT
-            var Utxos = NeblioTransactionHelpers.GetAddressNeblUtxo(address, 0.0001, amount).Result;
+            var Utxos = await NeblioTransactionHelpers.GetAddressNeblUtxo(address, 0.0001, amount);
 
             //Assert  
             Assert.NotEmpty(Utxos);
@@ -119,7 +119,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning an empty Utxos list for incorrect addres. Same validation applies when required amount is higer than available Neblios.
         /// </summary>
         [Fact]
-        public void GetSendAmount_EmptyUtxos_Test()
+        public async void GetSendAmount_EmptyUtxos_Test()
         {                        
             //Arrange
             string address = "123";
@@ -139,7 +139,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionInfoResponse);
 
             //ACT
-            var Utxos = NeblioTransactionHelpers.GetAddressNeblUtxo(address, 0.0001, amount).Result;
+            var Utxos = await NeblioTransactionHelpers.GetAddressNeblUtxo(address, 0.0001, amount);
 
             //Assert  
             Assert.Empty(Utxos);

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetSendAmountTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/GetSendAmountTest.cs
@@ -24,7 +24,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning amount correctly.
         /// </summary>
         [Fact]
-        public void GetSendAmount_Valid_Test()
+        public async void GetSendAmount_Valid_Test()
         {
             //Arrange
             var transactionId = "123";
@@ -61,7 +61,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(transactionId)).ReturnsAsync(transactionObject);
 
             //ACT
-            var txinfo = NeblioTransactionHelpers.GetTransactionInfo(transactionId).Result;
+            var txinfo = await NeblioTransactionHelpers.GetTransactionInfo(transactionId);
             var amount = NeblioTransactionHelpers.GetSendAmount(txinfo, address);
 
             //Assert  
@@ -72,7 +72,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning an error result for incorrect address and incorrect transactionId.
         /// </summary>
         [Fact]
-        public void GetSendAmount_Exception_Test()
+        public async void GetSendAmount_Exception_Test()
         {
             //Arrange
             var transactionId = "cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6"; //Incorrect transactionId
@@ -88,7 +88,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(transactionId)).ReturnsAsync(transactionObject);
 
             //ACT            
-            var txinfo = NeblioTransactionHelpers.GetTransactionInfo(transactionId).Result;
+            var txinfo = await NeblioTransactionHelpers.GetTransactionInfo(transactionId);
 
             //Assert
             var exception = Assert.Throws<Exception>(() => NeblioTransactionHelpers.GetSendAmount(txinfo, address));
@@ -99,11 +99,11 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning an error result for incorrect address and incorrect transactionId.
         /// </summary>
         [Fact]
-        public void GetSendAmount_EmptyInAndOutVectors_Test()
+        public async void GetSendAmount_EmptyInAndOutVectors_Test()
         {
             //Arrange
             var transactionId = "cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6"; //Incorrect transactionId
-            string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh"; 
+            string address = "NPvfpRCmDNcJjCZvDuAB9QsFC32gVThWdh";
 
             var emptyTransactionObject = new GetTransactionInfoResponse()
             {
@@ -114,7 +114,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(transactionId)).ReturnsAsync(emptyTransactionObject);
 
             //ACT            
-            var txinfo = NeblioTransactionHelpers.GetTransactionInfo(transactionId).Result;
+            var txinfo = await NeblioTransactionHelpers .GetTransactionInfo(transactionId);
             double amount = NeblioTransactionHelpers.GetSendAmount(txinfo, address);
 
             //Assert

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/SendNeblioTransactionTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/SendNeblioTransactionTest.cs
@@ -26,7 +26,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if sendTransaction method is working as expected with correct parameters.
         /// </summary>
         [Fact]
-        public void SendNeblioTransaction_Valid_Test()
+        public async void SendNeblioTransaction_Valid_Test()
         {
             //Arrange           
 
@@ -135,7 +135,7 @@ namespace VEFrameworkUnitTest.Neblio
             _client.Setup(x => x.GetTransactionInfoAsync(It.IsAny<string>())).ReturnsAsync(transactionObject);
             _client.Setup(x => x.BroadcastTxAsync(It.IsAny<BroadcastTxRequest>())).ReturnsAsync(broadcastTxResponse);
 
-            var result = CheckSpendableNeblio(.0009).Result;
+            var result = await CheckSpendableNeblio(.0009);
 
             var AccountKey = new EncryptionKey(Key)
             {
@@ -143,7 +143,7 @@ namespace VEFrameworkUnitTest.Neblio
             };
             AccountKey.LoadPassword(password);
             
-            var neblioTransactionResult = NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2).Result;
+            var neblioTransactionResult = await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2);
 
             Assert.Equal(transactionId, neblioTransactionResult);
         }
@@ -152,11 +152,11 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning an error result if Data object is null.
         /// </summary>
         [Fact]
-        public void SendNeblioTransaction_Data_Null_Test()
+        public async void SendNeblioTransaction_Data_Null_Test()
         {
             string message = "Data cannot be null!";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(null, null, new List<Utxos>())).Result;
-            Assert.Equal(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(null, null, new List<Utxos>()));
+            Assert.Equal(message, exception.Result.Message);
         }
 
         /// <summary>
@@ -167,8 +167,8 @@ namespace VEFrameworkUnitTest.Neblio
         {
             SendTxData txData = new SendTxData();
             string message = "Account cannot be null!";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(txData, null, new List<Utxos>())).Result;
-            Assert.Equal(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(txData, null, new List<Utxos>()));
+            Assert.Equal(message, exception.Result.Message);
         }
 
         /// <summary>
@@ -181,8 +181,8 @@ namespace VEFrameworkUnitTest.Neblio
             EncryptionKey encryptionKey = new EncryptionKey("Test");
 
             string message = "Cannot send transaction. cannot create receiver address!";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(txData, encryptionKey, new List<Utxos>())).Result;
-            Assert.Equal(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(txData, encryptionKey, new List<Utxos>()));
+            Assert.Equal(message, exception.Result.Message);
         }
 
         /// <summary>
@@ -214,8 +214,8 @@ namespace VEFrameworkUnitTest.Neblio
             AccountKey.LoadPassword(password);
 
             string message = "Cannot create the transaction object.";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, null)).Result;
-            Assert.Equal(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, null));
+            Assert.Equal(message, exception.Result.Message);
         }
 
         /// <summary>
@@ -333,8 +333,8 @@ namespace VEFrameworkUnitTest.Neblio
             var result = CheckSpendableNeblio(.1).Result;
 
             string message = "Exception during creating outputs. ";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2)).Result;
-            Assert.Contains(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2));
+            Assert.Contains(message, exception.Result.Message);
         }
         
         /// <summary>
@@ -459,8 +459,8 @@ namespace VEFrameworkUnitTest.Neblio
             AccountKey.LoadPassword(password);
 
             string message = "Cannot send token transaction. Password is not filled and key is encrypted or unlock account!";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2)).Result;
-            Assert.Equal(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2));
+            Assert.Equal(message, exception.Result.Message);
         }
 
         /// <summary>
@@ -585,8 +585,8 @@ namespace VEFrameworkUnitTest.Neblio
             AccountKey.LoadPassword(password);
 
             string message = "Cannot broadcast transaction.";
-            var exception = Assert.ThrowsAsync<Exception>(() => NeblioTransactionHelpers.SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2)).Result;
-            Assert.Contains(message, exception.Message);
+            var exception = Assert.ThrowsAsync<Exception>(async () => await NeblioTransactionHelpers .SendNeblioTransactionAPIAsync(sendTxData, AccountKey, result.Item2));
+            Assert.Contains(message, exception.Result.Message);
 
         }
         

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/ValidateOneTokenNFTUtxoTest.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Neblio/ValidateOneTokenNFTUtxoTest.cs
@@ -21,7 +21,7 @@ namespace VEFrameworkUnitTest.Neblio
         /// Unit test method to verify if system is returning an error result if an address is not having enough Neblio.
         /// </summary>
         [Fact]
-        public void ValidateOneTokenNFTUtxo_Valid_Test()
+        public async void ValidateOneTokenNFTUtxo_Valid_Test()
         {            
             #region AddressObject
 
@@ -111,7 +111,7 @@ namespace VEFrameworkUnitTest.Neblio
             string transactionId = "cb2cec4a0c3c6df5bf033e7da61a58eedb9a28ff2407c11b247b35f05baff6fb";
             int index = 1;
 
-            var result = NeblioTransactionHelpers.ValidateOneTokenNFTUtxo(address, tokenId, transactionId, index).Result;
+            var result = await NeblioTransactionHelpers.ValidateOneTokenNFTUtxo(address, tokenId, transactionId, index);
 
             Assert.Equal(index, result);
         }

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/VEFrameworkUnitTest.csproj
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/VEFrameworkUnitTest.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/VirtualEconomyFramework/VEconomy/VEconomy.csproj
+++ b/VirtualEconomyFramework/VEconomy/VEconomy.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="5.0.1" />


### PR DESCRIPTION
Added back cache implementation to calculating block height logic.
We are saving the cache for 10 seconds of sliding expiration that is if the object is not accessed for 10 seconds then it will be removed.
Replaced System.Runtime.Caching with Microsoft.Extensions.Caching.Memory package to resolve the issue.
Also added await and async for unit tests which involves calling async Neblio APIs.