### PR TITLE
Add appsetting.json to VENFT Blazor app

### DIFF
--- a/VirtualEconomyFramework/VENFTApp-Blazor/Services/AppData.cs
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Services/AppData.cs
@@ -6,7 +6,6 @@ using VEDriversLite.Bookmarks;
 
 public class AppData
 {
-    public static bool Development { get; } = true;
     public NeblioAccount Account { get; set; } = new NeblioAccount();
     public DogeAccount DogeAccount { get; set; } = new DogeAccount();
     public List<TokenOwnerDto> VENFTOwners = new List<TokenOwnerDto>();

--- a/VirtualEconomyFramework/VENFTApp-Blazor/Shared/NavMenu.razor
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/Shared/NavMenu.razor
@@ -1,4 +1,6 @@
-﻿@inject AppData AppData
+﻿@using Microsoft.Extensions.Configuration
+@inject AppData AppData
+@inject IConfiguration Configuration
 
 <div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href=""><img src="images/VENFT_logo.png" style="max-height:80px; min-width:100px; max-width:150px;" /></a>
@@ -49,24 +51,24 @@
                 <span class="oi oi-credit-card" aria-hidden="true"></span> Doge Wallet
             </NavLink>
         </li>
-        @if (AppData.Development)
+        @if (Convert.ToBoolean(Configuration["development"]))
         {
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="devices">
-                <span class="oi oi-dashboard" aria-hidden="true"></span> Devices
-            </NavLink>
-        </li>
-        <li class="nav-item px-3">
-            <NavLink class="nav-link " href="advanced">
-                <span class="oi oi-wrench" aria-hidden="true"></span> Advanced
-            </NavLink>
-        </li>
-        <!--
-        <li class="nav-item px-3">
-            <NavLink class="nav-link" href="tools">
-                <span class="oi oi-browser" aria-hidden="true"></span> Tools
-            </NavLink>
-        </li>-->
+            <li class="nav-item px-3">
+                <NavLink class="nav-link" href="devices">
+                    <span class="oi oi-dashboard" aria-hidden="true"></span> Devices
+                </NavLink>
+            </li>
+            <li class="nav-item px-3">
+                <NavLink class="nav-link " href="advanced">
+                    <span class="oi oi-wrench" aria-hidden="true"></span> Advanced
+                </NavLink>
+            </li>
+            <!--
+            <li class="nav-item px-3">
+                <NavLink class="nav-link" href="tools">
+                    <span class="oi oi-browser" aria-hidden="true"></span> Tools
+                </NavLink>
+            </li>-->
         }
     </ul>
 </div>
@@ -84,7 +86,7 @@
         }
     }
 
-    
+
 
     private bool collapseNavMenu = true;
     private string NavMenuCssClass => collapseNavMenu ? "collapse" : null;

--- a/VirtualEconomyFramework/VENFTApp-Blazor/wwwroot/appsettings.json
+++ b/VirtualEconomyFramework/VENFTApp-Blazor/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "development": false
+}


### PR DESCRIPTION
I have added the appsetting.json to the VENFT Blazor App. It is based on guidelines mentioned in #97 . 

It is very simple. 
- [add appsetting.json to the wwwroot folder](https://github.com/fyziktom/VirtualEconomyFramework/blob/97-add-appsettings-to-venftblazorapp/VirtualEconomyFramework/VENFTApp-Blazor/wwwroot/appsettings.json).  
- [add the using and inject settings](https://github.com/fyziktom/VirtualEconomyFramework/blob/9a582464d0b2f780477cd39b973fa4267e7ead64/VirtualEconomyFramework/VENFTApp-Blazor/Shared/NavMenu.razor#L2) 
-  [get settings in components like this](https://github.com/fyziktom/VirtualEconomyFramework/blob/9a582464d0b2f780477cd39b973fa4267e7ead64/VirtualEconomyFramework/VENFTApp-Blazor/Shared/NavMenu.razor#L54).

We should add the same settings in the VENFT OnePage #71 also.