### PR TITLE
151 entities blocks storage UI

### DIFF
--- a/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs
+++ b/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs
@@ -690,9 +690,9 @@ namespace TestVEDriversLite
                                 var phase2 = GetEntityBalanceBlocksAfterAlocationOfPVEBlocks(peerEntity, eGrid, dtmp);
 
                                 // get rest of consumption to device entity as blocks
-                                eGrid.AddBlocksToEntity(device.Id, phase2.Item2);
-                                eGrid.AddBlocksToEntity(device.Id, BlockHelpers.CloneBlocks(phase2.Item1, true, true, BlockType.Forwarded).ToList());
-                                eGrid.AddBlocksToEntity(device.Id, BlockHelpers.CloneBlocks(phase2.Item2, true, true, BlockType.NotCovered).ToList());
+                                eGrid.AddBlocksToEntity(peer.Key, phase2.Item2);
+                                eGrid.AddBlocksToEntity(peer.Key, BlockHelpers.CloneBlocks(phase2.Item1, true, true, BlockType.Forwarded).ToList());
+                                eGrid.AddBlocksToEntity(peer.Key, BlockHelpers.CloneBlocks(phase2.Item2, true, true, BlockType.NotCovered).ToList());
                                 // add rest of PVE production after consumption to network
                                 eGrid.AddBlocksToEntity(network.Id, phase2.Item1);
                             }

--- a/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs
+++ b/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs
@@ -160,6 +160,17 @@ namespace TestVEDriversLite
                     });
                     eGrid.AlocationSchemes.TryAdd(alocationScheme.Id, alocationScheme);
 
+                    // add PVE simulator to entity
+                    eGrid.AddSimulatorToEntity(pvesource.Id, PVESim);
+
+                    // add TDD Consumption simulators to entities
+                    eGrid.AddSimulatorToEntity(firstmeasurespotDevice.Id, 
+                                               new ConsumerTDDSimulator(new List<DataProfile>() { tdds[0] }));
+                    eGrid.AddSimulatorToEntity(device.Id, 
+                                               new ConsumerTDDSimulator(new List<DataProfile>() { tdds[0] }));
+                    eGrid.AddSimulatorToEntity(device3.Id, 
+                                               new ConsumerTDDSimulator(new List<DataProfile>() { tdds[0] }));
+
                     if (device != null && pvesource != null && mainbattery != null)
                     {
                         var dtmp = start;
@@ -171,25 +182,42 @@ namespace TestVEDriversLite
                         while (dtmp < dend)
                         {
                             Console.WriteLine($"Analysing {dtmp} Day {day} of {totalDays} total Days to analyze...");
+
+                            #region AddPVESimulatedBlocksManually
+
                             // simulate production for each hour of day
+                            // note: produce blocks from PVE just for precise output at the end of script
+                            // note: For case of internal calc it is added as simulator to "pvesource" entity
                             var productionblocks = PVESim.GetTotalPeakPowerInHourTimeframeBlocks(dtmp, 
                                                                                                  dtmp.AddDays(1), 
                                                                                                  coord, 1.0, 
                                                                                                  pvesource.Id).ToList();
-                            
+
+                            /*
+                             * The PVE simulator is added to entity now. 
+                             * But this commented part is another way how to create and add simulated blocks from PVE
                             // add day production blocks to the mainPVE entity
                             eGrid.AddBlocksToEntity(pvesource.Id, productionblocks);
+                            */
+                            #endregion
 
+                            #region AddTDDSimulatedBlocksManually
+                                       
                             // get consumption based on TDD for MeasureSpot1 (place where the PVE is connected through)
                             // it will cover whole consumption of this entity. 
+                            // it is produced just for ouptuts purposes now. main module is in simulator in entity
                             var consumptionblocks = ConsumersHelpers.GetConsumptionBlocksBasedOnTDD(tdds[0],
                                                                                                     dtmp,
                                                                                                     dtmp.AddDays(1),
                                                                                                     BlockTimeframe.Hour,
                                                                                                     firstmeasurespotDevice.Id);
-
+                            /*
+                             * The TDD consumption simulator is added to entity now.
+                             * But this commented part is another way how to create and add simulated blocks from TDDs  
                             // add day consumption blocks to the device in Frist Measure Spot entity
                             eGrid.AddBlocksToEntity(firstmeasurespotDevice.Id, consumptionblocks.Item1);
+                            */
+                            #endregion
 
                             // get two list of blocks after first phase of calculation,
                             // when first measured spot (connection place for PVE) consume imediatelly what it can
@@ -487,6 +515,400 @@ namespace TestVEDriversLite
                 }
 
                 foreach(var line in lines)
+                    FileHelpers.AppendLineToTextFile(line, filename);
+
+                var header = "Date\t" +
+                             "totalDT\t" +
+                             "totalDTOverProduction\t" +
+                             "totalNT\t" +
+                             "totalNTOverProduction\t" +
+                             "totalproduced\t" +
+                             "totalOverProducedAfterConsumedImmediately\t" +
+                             "totalStored\t" +
+                             "totalUsedFromStorage\t" +
+                             "totalConsumptionFirstMeasureSpot\t" +
+                             "totalfirstmeasurespotForwardedSourceBlocks\t" +
+                             "totalfirstmeasureSpotNotCoveredConsuptionBlocks\t" +
+                             "totalConsumptionDevice\t" +
+                             "totalDeviceForwardedSourceBlocks\t" +
+                             "totaldeviceNotCoveredConsuptionBlocks\t" +
+                             "totalConsumptionDevice3\t" +
+                             "totalDevice3ForwardedSourceBlocks\t" +
+                             "totaldevice3NotCoveredConsuptionBlocks";
+
+                FileHelpers.AppendLineToTextFile(header, filenameBilance);
+                foreach (var line in linesBilance)
+                    FileHelpers.AppendLineToTextFile(line, filenameBilance);
+
+                // export created blocks 
+                var config = eGrid.ExportToConfig();
+                if (config.Item1)
+                    FileHelpers.WriteTextToFile($"{DateTime.UtcNow.ToString("yyyy_MM_ddThh_mm_ss")}-eGrid.json", config.Item2);
+            }
+        }
+
+
+        [TestEntry]
+        public static void EB_LoadTDDAndCalcBalanceShort(string param)
+        {
+            EB_LoadTDDAndCalcBalanceShortAsync(param);
+        }
+        public static async Task EB_LoadTDDAndCalcBalanceShortAsync(string param)
+        {
+            // SET Coordinates of PVE
+            Coordinates coord = new Coordinates(49.194103, 16.608998);
+            // SET Start of the simulation
+            var start = new DateTime(2022, 1, 1);
+            // SET Number of days which you want to simulate
+            var daysOfSimulation = 365;
+            // SET start of Day tariff
+            var startOfDT = new TimeSpan(6, 0, 0);
+            // SET start of Night tariff
+            var startOfNT = new TimeSpan(21, 0, 0);
+
+            // end of the simulation
+            var end = start.AddDays(daysOfSimulation);
+
+            var split = param.Split(',');
+            if (split.Length == 4)
+            {
+                // name of file with TDDs
+                var tdd = split[0];
+                // name of config file for grid (for example in Demo.Energy/wwwroot: "sampledata.json")
+                var grid = split[1];
+                // name of config file for PVE simulator (for example in Demo.Energy/wwwroot: "samplepve.json")
+                var pve = split[2];
+                // name of config file for Battery Storage simulator (for example in Demo.Energy/wwwroot: "samplestorage.json")
+                var storage = split[3];
+
+                // create simulator objects
+                var eGrid = new BaseEntitiesHandler();
+                var PVESim = new PVPanelsGroupsHandler();
+                var StorageSim = new BatteryBlockHandler(null,
+                                                         "battery",
+                                                         BatteryBlockHandler.DefaultChargingFunction,
+                                                         BatteryBlockHandler.DefaultDischargingFunction);
+
+                // load configs of simulators
+                var tddfromfile = FileHelpers.ReadTextFromFile(tdd);
+                var cpve = FileHelpers.ReadTextFromFile(pve);
+                var cgrid = FileHelpers.ReadTextFromFile(grid);
+                var cstorage = FileHelpers.ReadTextFromFile(storage);
+
+                // prepare output files names
+                var lines = new List<string>();
+                var filename = $"{DateTime.UtcNow.ToString("yyyy_MM_ddThh_mm_ss")}-blocks.txt";
+                var linesBilance = new List<string>();
+                var filenameBilance = $"{DateTime.UtcNow.ToString("yyyy_MM_ddThh_mm_ss")}-grid-bilance.txt";
+
+                if (!string.IsNullOrEmpty(tddfromfile) && !string.IsNullOrEmpty(cgrid) && !string.IsNullOrEmpty(cpve))
+                {
+                    var tdds = ConsumersHelpers.LoadTDDs(tddfromfile);
+
+                    // load simulators
+                    if (!eGrid.LoadFromConfig(cgrid).Item1) return;
+                    if (!PVESim.ImportConfig(cpve).Item1) return;
+                    if (!StorageSim.ImportConfig(cstorage).Item1) return;
+
+                    var lastStorageLoadedEndState = 0.0;
+
+                    // load entities because of their Ids (blocks will reffer to their Ids)
+                    var network = eGrid.FindEntityByName("network");
+                    var device = eGrid.FindEntityByName("device1");
+                    var device3 = eGrid.FindEntityByName("device3");
+                    var pvesource = eGrid.FindEntityByName("mainPVE");
+                    var firstmeasurespot = eGrid.FindEntityByName("FirstMeasureSpot");
+                    var firstmeasurespotDevice = eGrid.FindEntityByName("firstspotdevice");
+                    var mainbattery = eGrid.FindEntityByName("mainbattery");
+
+                    var pveInvestment = PVESim.TotalInvestmentBasedOnPeakPower;
+                    var storageInvestment = StorageSim.TotalInvestmentBasedOnPeakPower;
+
+                    // create alocation scheme
+                    var alocationScheme = new AlocationScheme()
+                    {
+                        Id = System.Guid.NewGuid().ToString(),
+                        IsActive = true,
+                        Name = "Main Scheme",
+                        MainDepositPeerId = network.Id
+                    };
+                    alocationScheme.DepositPeers.TryAdd(device.Id, new DepositPeer()
+                    {
+                        PeerId = device.Id,
+                        Name = device.Name,
+                        Percentage = 40
+                    });
+                    alocationScheme.DepositPeers.TryAdd(device3.Id, new DepositPeer()
+                    {
+                        PeerId = device3.Id,
+                        Name = device3.Name,
+                        Percentage = 40
+                    });
+                    eGrid.AlocationSchemes.TryAdd(alocationScheme.Id, alocationScheme);
+
+                    // add PVE simulator to entity
+                    eGrid.AddSimulatorToEntity(pvesource.Id, PVESim);
+
+                    // add TDD Consumption simulators to entities
+                    eGrid.AddSimulatorToEntity(firstmeasurespotDevice.Id,
+                                               new ConsumerTDDSimulator(new List<DataProfile>() { tdds[0] }));
+                    eGrid.AddSimulatorToEntity(device.Id,
+                                               new ConsumerTDDSimulator(new List<DataProfile>() { tdds[0] }));
+                    eGrid.AddSimulatorToEntity(device3.Id,
+                                               new ConsumerTDDSimulator(new List<DataProfile>() { tdds[0] }));
+
+                    if (device != null && pvesource != null && mainbattery != null)
+                    {
+                        var dtmp = start;
+                        var dend = end;
+
+                        var totalDays = (end - start).TotalDays;
+                        var day = 1;
+                        // iterate through days until end
+                        while (dtmp < dend)
+                        {
+                            Console.WriteLine($"Analysing {dtmp} Day {day} of {totalDays} total Days to analyze...");
+
+                            //--------------------------Phase 1-------------------------
+                            // first phase of calculation, first measure spot which connetcts PVE
+                            var firstmeasuredspotPhase1 = GetEntityBalanceBlocksAfterAlocationOfPVEBlocks(firstmeasurespot, eGrid, dtmp);
+                            // add day consumption blocks to the device in Frist Measure Spot entity after the consumption is covered by PVE in first entity
+                            eGrid.AddBlocksToEntity(firstmeasurespotDevice.Id, firstmeasuredspotPhase1.Item2);                         
+                            // add day production blocks to the mainPVE entity based on allocation scheme
+                            // if there is something over the alocation scheme peers values it is stored in network entity
+                            eGrid.AddBlocksToEntity(alocationScheme.MainDepositPeerId,
+                                                    firstmeasuredspotPhase1.Item1,
+                                                    alocationScheme.Id);
+
+                            //--------------------------Phase 2 - device-------------------------
+
+                            foreach (var peer in alocationScheme.DepositPeers)
+                            {
+                                var peerEntity = eGrid.GetEntity(peer.Key, EntityType.Consumer);
+
+                                // calculate the bilance for the device
+                                var phase2 = GetEntityBalanceBlocksAfterAlocationOfPVEBlocks(peerEntity, eGrid, dtmp);
+
+                                // get rest of consumption to device entity as blocks
+                                eGrid.AddBlocksToEntity(device.Id, phase2.Item2);
+                                eGrid.AddBlocksToEntity(device.Id, BlockHelpers.CloneBlocks(phase2.Item1, true, true, BlockType.Forwarded).ToList());
+                                eGrid.AddBlocksToEntity(device.Id, BlockHelpers.CloneBlocks(phase2.Item2, true, true, BlockType.NotCovered).ToList());
+                                // add rest of PVE production after consumption to network
+                                eGrid.AddBlocksToEntity(network.Id, phase2.Item1);
+                            }
+
+                            //--------------------------Phase 3---------------------
+                            var productionPhase3tmp = GetEntityBalanceBlocksAfterAlocationOfPVEBlocks(network, eGrid, dtmp);
+
+                            // calculate actual PVE rest in network
+                            var productionPhase3 = eGrid.GetConsumptionOfEntity(network.Id,
+                                                                                BlockTimeframe.Hour,
+                                                                                dtmp,
+                                                                                dtmp.AddDays(1),
+                                                                                true,
+                                                                                false,
+                                                                                new List<BlockDirection>() { BlockDirection.Created },
+                                                                                new List<BlockType>() { BlockType.Simulated },
+                                                                                false);
+
+                            var productionPhase3Profile = DataProfileHelpers.ConvertBlocksToDataProfile(productionPhase3);
+
+                            // calculate actual PVE rest in network
+                            var consumptionPhase3 = eGrid.GetConsumptionOfEntity(network.Id,
+                                                                                 BlockTimeframe.Hour,
+                                                                                 dtmp,
+                                                                                 dtmp.AddDays(1),
+                                                                                 true,
+                                                                                 false,
+                                                                                 new List<BlockDirection>() { BlockDirection.Consumed },
+                                                                                 new List<BlockType>() { BlockType.Simulated },
+                                                                                 false);
+
+                            var consumptionPhase3Profile = DataProfileHelpers.ConvertBlocksToDataProfile(consumptionPhase3);
+
+                            //--------------------------Phase 4 - storage---------------------
+                            // create charge and discharge and balance data profiles for storage
+                            var profiles = StorageSim.GetChargingAndDischargingProfiles(productionPhase3Profile,
+                                                                                        consumptionPhase3Profile,
+                                                                                        true,
+                                                                                        lastStorageLoadedEndState);
+                            
+                            if (profiles != null &&
+                                profiles.TryGetValue("charge", out var ch) &&
+                                profiles.TryGetValue("dcharge", out var dch) &&
+                                profiles.TryGetValue("discharge", out var disch) &&
+                                profiles.TryGetValue("ddischarge", out var ddisch) &&
+                                profiles.TryGetValue("balance", out var bil))
+                            {
+                                if (ch.ProfileData.TryGetValue(ch.LastDate, out var lastcharge) &&
+                                    disch.ProfileData.TryGetValue(disch.LastDate, out var lastdischarge))
+                                {
+                                    // get blocks which represents stored energy in battery per hour for one day
+                                    // divide blocks values by 1000 to convert to kWh
+                                    var dchargeblocks = DataProfileHelpers.ConvertDataProfileToBlocks(dch,
+                                                                                                      BlockDirection.Stored,
+                                                                                                      BlockType.Simulated,
+                                                                                                      mainbattery.Id,
+                                                                                                      1000,
+                                                                                                      true).ToList();
+                                    // get blocks which represents energy pulled from the storage (atc as source = BlockDirection.Created in model)
+                                    // divide blocks values by 1000 to convert to kWh
+                                    var ddischargeblocks = DataProfileHelpers.ConvertDataProfileToBlocks(ddisch,
+                                                                                                         BlockDirection.Created,
+                                                                                                         BlockType.Simulated,
+                                                                                                         mainbattery.Id,
+                                                                                                         1000,
+                                                                                                         true).ToList();
+
+                                    // add blocks to battery entity
+                                    eGrid.AddBlocksToEntity(mainbattery.Id, dchargeblocks);
+                                    eGrid.AddBlocksToEntity(mainbattery.Id, ddischargeblocks);
+
+                                    // get consumption of the whole network in the day
+                                    var netw = eGrid.GetConsumptionOfEntity(network.Id,
+                                                                            BlockTimeframe.Hour,
+                                                                            dtmp,
+                                                                            dtmp.AddDays(1),
+                                                                            true,
+                                                                            true,
+                                                                            new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
+                                                                            new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real },
+                                                                            false);
+
+                                    // get consumption of the whole network in the day in window of Day Tariff
+                                    var netwDT = eGrid.GetConsumptionOfEntityWithWindow(network.Id,
+                                                                                        BlockTimeframe.Hour,
+                                                                                        dtmp,
+                                                                                        dtmp.AddDays(1),
+                                                                                        dtmp + startOfDT,
+                                                                                        dtmp + startOfNT,
+                                                                                        false,
+                                                                                        true,
+                                                                                        true,
+                                                                                        new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
+                                                                                        new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real },
+                                                                                        false);
+
+                                    // get consumption of the whole network in the day in window of Night Tariff (set invertWindow parameter as true)
+                                    var netwNT = eGrid.GetConsumptionOfEntityWithWindow(network.Id,
+                                                                                        BlockTimeframe.Hour,
+                                                                                        dtmp,
+                                                                                        dtmp.AddDays(1),
+                                                                                        dtmp + startOfDT,
+                                                                                        dtmp + startOfNT,
+                                                                                        true,
+                                                                                        true,
+                                                                                        true,
+                                                                                        new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
+                                                                                        new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real },
+                                                                                        false);
+
+
+
+                                    ////////////// whole day stats
+                                    // total needed from Day tariff
+                                    var totalDT = Math.Round(netwDT.Where(b => b.Amount < 0).Select(b => b.Amount).Sum(), 4);
+                                    // total over production during the day if some exists
+                                    var totalDTOverProduction = Math.Round(netwDT.Where(b => b.Amount > 0).Select(b => b.Amount).Sum(), 4);
+                                    // total needed from Night tariff
+                                    var totalNT = Math.Round(netwNT.Where(b => b.Amount < 0).Select(b => b.Amount).Sum(), 4);
+                                    // total over production during the night if some exists
+                                    var totalNTOverProduction = Math.Round(netwNT.Where(b => b.Amount > 0).Select(b => b.Amount).Sum(), 4);
+
+                                    // total produced from own PVE
+                                    var pveproduced = pvesource.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                               .Where(b => b.Amount > 0)
+                                                               .Select(b => b.Amount);
+                                    var totalproduced = Math.Round(pveproduced.Sum(), 4);
+                                    // total produced from own PVE over the consumption during the production phase of PVE
+                                    var totalOverProducedAfterConsumedImmediately = Math.Round(productionPhase3Profile.ProfileData.Values.Sum(), 4);
+                                    // total stored in storage from PVE production
+                                    var totalStored = Math.Round(dch.ProfileData.Values.Sum(), 4);
+                                    // total used from storage for consumption 
+                                    var totalUsedFromStorage = Math.Round(ddisch.ProfileData.Values.Sum() / 1000, 4);
+
+
+                                    //--------------------------First measure spot---------------------
+                                    // total consumption from first measure spot (base on tdd here)
+                                    var consumedFirstMS = firstmeasurespotDevice.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                                                .Where(b => b.Amount > 0)
+                                                                                .Select(b => b.Amount);
+                                    var totalConsumptionFirstMeasureSpot = Math.Round(consumedFirstMS.Sum(), 4);
+                                    // device not consumed and forwarded up
+                                    var totalfirstmeasurespotForwardedSourceBlocks = Math.Round(firstmeasuredspotPhase1.Item1.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
+                                    // device not covered
+                                    var totalfirstmeasureSpotNotCoveredConsuptionBlocks = Math.Round(firstmeasuredspotPhase1.Item2.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
+                                    
+                                    //-------------------------------Device spot------------------------
+                                    // total consumption on device 
+                                    var consumedDevice = device.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                               .Where(b => b.Amount > 0)
+                                                               .Select(b => b.Amount);
+                                    var totalConsumptionDevice = Math.Round(consumedDevice.Sum(), 4);
+                                    // device not consumed and forwarded up
+                                    var forwardedByDevice = device.Blocks.Values.Where(b => b.Type == BlockType.Forwarded && b.StartTime >= dtmp && b.EndTime <= dtmp.AddDays(1))
+                                                                                .Select(b => b.Amount);
+                                    var totalDeviceForwardedSourceBlocks = Math.Round(forwardedByDevice.Sum(), 4);
+                                    // device not covered
+                                    var notCoveredByDevice = device.Blocks.Values.Where(b => b.Type == BlockType.NotCovered && b.StartTime >= dtmp && b.EndTime <= dtmp.AddDays(1))
+                                                                                .Select(b => b.Amount);
+                                    var totaldeviceNotCoveredConsuptionBlocks = Math.Round(notCoveredByDevice.Sum(), 4);
+
+                                    //-----------------------------------Device3 spot--------------
+                                    // total consumption on device3
+                                    var consumedDevice3 = device3.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                                 .Where(b => b.Amount > 0)
+                                                                 .Select(b => b.Amount);
+                                    var totalConsumptionDevice3 = Math.Round(consumedDevice3.Sum(), 4);
+                                    // device3 not consumed and forwarded up
+                                    var forwardedByDevice3 = device3.Blocks.Values.Where(b => b.Type == BlockType.Forwarded && b.StartTime >= dtmp && b.EndTime <= dtmp.AddDays(1))
+                                                                                  .Select(b => b.Amount);
+                                    var totalDevice3ForwardedSourceBlocks = Math.Round(forwardedByDevice3.Sum(), 4);
+                                    // device3 not covered
+                                    var notCoveredByDevice3 = device3.Blocks.Values.Where(b => b.Type == BlockType.NotCovered && b.StartTime >= dtmp && b.EndTime <= dtmp.AddDays(1))
+                                                                                .Select(b => b.Amount);
+                                    var totaldevice3NotCoveredConsuptionBlocks = Math.Round(notCoveredByDevice3.Sum(), 4);
+
+                                    // get rest in batery to load it next day morning as overstored from last day
+                                    // it is inserted in charge and discharge profiles calculations
+                                    if (bil.ProfileData.TryGetValue(bil.LastDate, out var val))
+                                        lastStorageLoadedEndState = val;
+
+                                    // add line with day stats
+                                    linesBilance.Add($"{dtmp}\t" +
+                                                     $"{totalDT}\t" +
+                                                     $"{totalDTOverProduction}\t" +
+                                                     $"{totalNT}\t" +
+                                                     $"{totalNTOverProduction}\t" +
+                                                     $"{totalproduced}\t" +
+                                                     $"{totalOverProducedAfterConsumedImmediately}\t" +
+                                                     $"{totalStored}\t" +
+                                                     $"{totalUsedFromStorage}\t" +
+                                                     $"{totalConsumptionFirstMeasureSpot}\t" +
+                                                     $"{totalfirstmeasurespotForwardedSourceBlocks}\t" +
+                                                     $"{totalfirstmeasureSpotNotCoveredConsuptionBlocks}\t" +
+                                                     $"{totalConsumptionDevice}\t" +
+                                                     $"{totalDeviceForwardedSourceBlocks}\t" +
+                                                     $"{totaldeviceNotCoveredConsuptionBlocks}\t" +
+                                                     $"{totalConsumptionDevice3}\t" +
+                                                     $"{totalDevice3ForwardedSourceBlocks}\t" +
+                                                     $"{totaldevice3NotCoveredConsuptionBlocks}");
+
+                                    // create line for export
+                                    var line = $"{dtmp}";
+                                    foreach (var v in netw)
+                                        line += $"\t{Math.Round(v.Amount, 4)}";
+
+                                    lines.Add(line);
+                                }
+                            }
+                            dtmp = dtmp.AddDays(1);
+                            day++;
+                        }
+                    }
+                }
+
+                foreach (var line in lines)
                     FileHelpers.AppendLineToTextFile(line, filename);
 
                 var header = "Date\t" +

--- a/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs
+++ b/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs
@@ -113,8 +113,8 @@ namespace TestVEDriversLite
 
                     // load simulators
                     if (!eGrid.LoadFromConfig(cgrid).Item1) return;
-                    if (!PVESim.ImportConfigFromJson(cpve)) return;
-                    if (!StorageSim.ImportConfigFromJson(cstorage)) return;
+                    if (!PVESim.ImportConfig(cpve).Item1) return;
+                    if (!StorageSim.ImportConfig(cstorage).Item1) return;
 
                     var lastStorageLoadedEndState = 0.0;
 
@@ -143,7 +143,8 @@ namespace TestVEDriversLite
                     {
                         Id = System.Guid.NewGuid().ToString(),
                         IsActive = true,
-                        Name = "Main Scheme"
+                        Name = "Main Scheme",
+                        MainDepositPeerId = network.Id
                     };
                     alocationScheme.DepositPeers.TryAdd(device.Id, new DepositPeer()
                     {
@@ -222,8 +223,9 @@ namespace TestVEDriversLite
 
                             // add day production blocks to the mainPVE entity based on allocation scheme
                             // if there is something over the alocation scheme peers values it is stored in network entity
-                            eGrid.AddBlocksToEntity(network.Id, firstmeasuredspotPhase1.Item1, alocationScheme.Id);
-
+                            eGrid.AddBlocksToEntity(alocationScheme.MainDepositPeerId, 
+                                                    firstmeasuredspotPhase1.Item1, 
+                                                    alocationScheme.Id);
 
                             /////////////////////////
                             // add another consumptions to the entities

--- a/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/App.razor
+++ b/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/App.razor
@@ -1,4 +1,7 @@
-﻿@inject AppData AppData
+﻿@using VEDriversLite.EntitiesBlocks.Blocks.Dto
+@using VEDriversLite.Common
+
+@inject AppData AppData
 @inject HttpClient Http
 
 <Router AppAssembly="@typeof(App).Assembly">
@@ -19,21 +22,120 @@
 <NotificationProvider />
 
 @code {
+    double panelAzimuthE = MathHelpers.DegreeToRadians(-40);
+    double panelAzimuthS = MathHelpers.DegreeToRadians(0);
+    double panelAzimuthW = MathHelpers.DegreeToRadians(40);
+    string name = "mytest";
+    int DurationInDays = 1;
+    DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+    DateTime end = new DateTime(2022, 1, 2, 0, 0, 0);
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        /*
-        if (firstRender)
+        if (!AppData.TDDsLoaded)
         {
-            AppData.RootItemId = "7b27c442-ad40-4679-b6d5-8873d9763996";
-            AppData.RootItemName = "network";
-            var storeddata = await Http.GetStringAsync("sampledata.json");
-            if (storeddata != null)
-                AppData.StoredConfig = storeddata;
+            var tddfromfile = await Http.GetStringAsync("tdd.csv");
+            var tdds = new List<DataProfile>();
+            if (tddfromfile != null)
+            {
+                tdds = ConsumersHelpers.LoadTDDs(tddfromfile);
+                AppData.TDDs = tdds;
+                AppData.TDDsLoaded = true;
+            }
+        }
 
-            AppData.EntitiesHandler.LoadFromConfig(AppData.StoredConfig);
+        if (!AppData.BatteryStorageSimulatorLoaded)
+        {
+            var storagedata = await Http.GetStringAsync("samplestorage.json");
+            if (storagedata != null)
+                AppData.StoredBatteryStorageConfig = storagedata;
+
+            if (storagedata != null && !AppData.BatteryStorage.ImportConfig(storagedata).Item1)
+            {
+                setCommonBattery();
+                AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
+                AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
+
+                AppData.BatteryStorageSimulatorLoaded = true;
+            }
 
         }
-        */
+
+        if (!AppData.PVESimulatorLoaded)
+        {
+            end = start.AddDays(DurationInDays);
+            var storeddata = await Http.GetStringAsync("samplepve.json");
+            if (storeddata != null)
+                AppData.StoredPVEConfig = storeddata;
+
+            if (storeddata != null && !AppData.PVEGrid.ImportConfig(storeddata).Item1)
+            {
+                panelAzimuthE = MathHelpers.DegreeToRadians(-40);
+                panelAzimuthS = MathHelpers.DegreeToRadians(0);
+                panelAzimuthW = MathHelpers.DegreeToRadians(60);
+
+                var eastPanelsId = AppData.PVEGrid.AddGroup("East");
+                var southPanelsId = AppData.PVEGrid.AddGroup("South");
+                var westPanelsId = AppData.PVEGrid.AddGroup("West");
+
+                SetCommonPanel();
+                // set template panel in this PVE
+                AddPanelToGroup(eastPanelsId, panelAzimuthE, true, 3);
+                AddPanelToGroup(southPanelsId, panelAzimuthS, true, 6);
+                AddPanelToGroup(westPanelsId, panelAzimuthW, true, 8);
+            }
+
+            AppData.PVESimulatorLoaded = true;
+            await InvokeAsync(StateHasChanged);
+            await Task.Delay(1);
+            await InvokeAsync(StateHasChanged);
+        }
+
         await base.OnAfterRenderAsync(firstRender);
+    }
+
+
+    private void setCommonBattery()
+    {
+        AppData.BatteryStorage.SetCommonBattery(new BatteryBlock()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Capacity = 10000,
+                InternalResistance = 0.1,
+                MaximumChargePower = 2000,
+                MaximumDischargePower = 2000
+            });
+    }
+
+    private void SetCommonPanel()
+    {
+        if (AppData.PVEGrid != null)
+        {
+            var panel = new PVPanel()
+                {
+                    Name = "test",
+                    Azimuth = 0,
+                    BaseAngle = MathHelpers.DegreeToRadians(23),
+                    DirtRatio = 0.05 / 365,
+                    Efficiency = 1,
+                    Height = 2000,
+                    Width = 1000,
+                    Latitude = AppData.DefaultCoordinates.Latitude,
+                    Longitude = AppData.DefaultCoordinates.Longitude,
+                    PeakPower = 0.3,
+                    PanelPeakAngle = MathHelpers.DegreeToRadians(90)
+                };
+            AppData.PVEGrid.SetCommonPanel(panel);
+        }
+    }
+    private void AddPanelToGroup(string groupId, double azimuth = 0, bool setAzimuth = false, int count = 1)
+    {
+        SetCommonPanel();
+        if (setAzimuth)
+        {
+            AppData.PVEGrid.CommonPanel.Azimuth = azimuth;
+        }
+        var addedPanelsId = AppData.PVEGrid.AddPanelToGroup(groupId, AppData.PVEGrid.CommonPanel, count).ToList();
+
     }
 }

--- a/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/Analytics.razor
+++ b/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/Analytics.razor
@@ -19,52 +19,8 @@
         {
             rootItemId = AppData.RootItemId;
         }
-
-        if (!AppData.BatteryStorageSimulatorLoaded)
-        {
-            var storagedata = await Http.GetStringAsync("samplestorage.json");
-            if (storagedata != null)
-                AppData.StoredBatteryStorageConfig = storagedata;
-
-            if (storagedata != null && !AppData.BatteryStorage.ImportConfig(storagedata).Item1)
-            {
-                setCommonBattery();
-                AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
-                AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
-
-                AppData.BatteryStorageSimulatorLoaded = true;
-            }
-
-        }
-
-        if (!AppData.PVESimulatorLoaded)
-        {
-            storeddata = await Http.GetStringAsync("samplepve.json");
-            if (storeddata != null)
-                AppData.StoredPVEConfig = storeddata;
-
-            if (storeddata != null)
-                AppData.PVEGrid.ImportConfig(storeddata);
-
-            AppData.PVESimulatorLoaded = true;
-            await InvokeAsync(StateHasChanged);
-            await Task.Delay(1);
-        }
         
         await base.OnInitializedAsync();
-    }
-
-
-    private void setCommonBattery()
-    {
-        AppData.BatteryStorage.SetCommonBattery(new BatteryBlock()
-            {
-                Id = Guid.NewGuid().ToString(),
-                Capacity = 10000,
-                InternalResistance = 0.1,
-                MaximumChargePower = 2000,
-                MaximumDischargePower = 2000
-            });
     }
 
     private string rootItemId;

--- a/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/Analytics.razor
+++ b/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/Analytics.razor
@@ -26,7 +26,7 @@
             if (storagedata != null)
                 AppData.StoredBatteryStorageConfig = storagedata;
 
-            if (storagedata != null && !AppData.BatteryStorage.ImportConfigFromJson(storagedata))
+            if (storagedata != null && !AppData.BatteryStorage.ImportConfig(storagedata).Item1)
             {
                 setCommonBattery();
                 AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
@@ -44,7 +44,7 @@
                 AppData.StoredPVEConfig = storeddata;
 
             if (storeddata != null)
-                AppData.PVEGrid.ImportConfigFromJson(storeddata);
+                AppData.PVEGrid.ImportConfig(storeddata);
 
             AppData.PVESimulatorLoaded = true;
             await InvokeAsync(StateHasChanged);

--- a/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/PVESimulation.razor
+++ b/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/PVESimulation.razor
@@ -34,139 +34,29 @@
     PVESimulationGraph? graph;
     PVEYearGraph? ygraph;
     BatteryBlocksGroupCard? batterystorage;
-
-    Coordinates coord = new Coordinates(49.194103, 16.608998);
-    double panelAzimuthE = MathHelpers.DegreeToRadians(-40);
-    double panelAzimuthS = MathHelpers.DegreeToRadians(0);
-    double panelAzimuthW = MathHelpers.DegreeToRadians(40);
-    string name = "mytest";
-    int DurationInDays = 1;
     DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
     DateTime end = new DateTime(2022, 1, 2, 0, 0, 0);
     IEnumerable<(string,string)> groupIds = new List<(string,string)>();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!AppData.BatteryStorageSimulatorLoaded)
-        {
-            var storeddata = await Http.GetStringAsync("samplestorage.json");
-            if (storeddata != null)
-                AppData.StoredBatteryStorageConfig = storeddata;
-
-            if (storeddata != null && !AppData.BatteryStorage.ImportConfig(storeddata).Item1)
-            {
-                setCommonBattery();
-                AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
-                AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
-                
-                AppData.BatteryStorageSimulatorLoaded = true;
-            }
-
-            if (batterystorage != null)
-                await batterystorage.LoadData();
-
-        }
-
-        if (!AppData.PVESimulatorLoaded)
-        {
-            end = start.AddDays(DurationInDays);
-            var storeddata = await Http.GetStringAsync("samplepve.json");
-            if (storeddata != null)
-                AppData.StoredPVEConfig = storeddata;
-
-            if (storeddata != null && !AppData.PVEGrid.ImportConfig(storeddata).Item1)
-            {
-                panelAzimuthE = MathHelpers.DegreeToRadians(-40);
-                panelAzimuthS = MathHelpers.DegreeToRadians(0);
-                panelAzimuthW = MathHelpers.DegreeToRadians(60);
-
-                var eastPanelsId = AppData.PVEGrid.AddGroup("East");
-                var southPanelsId = AppData.PVEGrid.AddGroup("South");
-                var westPanelsId = AppData.PVEGrid.AddGroup("West");
-
-                SetCommonPanel();
-                // set template panel in this PVE
-                AddPanelToGroup(eastPanelsId, panelAzimuthE, true, 3);
-                AddPanelToGroup(southPanelsId, panelAzimuthS, true, 6);
-                AddPanelToGroup(westPanelsId, panelAzimuthW, true, 8);
-            }
-
-            groupIds = AppData.PVEGrid.PVPanelsGroups.Values.Where(p => p.Id != null).Select(p => (p.Id, p.Name));
-
-            AppData.PVESimulatorLoaded = true;
-            await InvokeAsync(StateHasChanged);
-            await Task.Delay(1);
-
-            if (pveblock != null)
-                await pveblock.Reload();
-
-            if (graph != null)
-                await graph.LoadData(start, groupIds, coord);
-
-            if (ygraph != null)
-                await ygraph.LoadData(start, groupIds, coord, false);
-
-            await InvokeAsync(StateHasChanged);
-        }
-        else 
+        if (firstRender && batterystorage != null)
+            await batterystorage.LoadData();
+        
+        if (AppData.PVESimulatorLoaded && firstRender)
         {
             groupIds = AppData.PVEGrid.PVPanelsGroups.Values.Where(p => p.Id != null).Select(p => (p.Id, p.Name));
             if (pveblock != null)
                 await pveblock.Reload();
 
             if (graph != null)
-                await graph.LoadData(start, groupIds, coord);
+                await graph.LoadData(start, groupIds, AppData.DefaultCoordinates);
 
             if (ygraph != null)
-                await ygraph.LoadData(start, groupIds, coord, false);
+                await ygraph.LoadData(start, groupIds, AppData.DefaultCoordinates, false);
 
         }
 
         await base.OnAfterRenderAsync(firstRender);
-    }
-
-    private void SetCommonPanel()
-    {
-        if (AppData.PVEGrid != null)
-        {
-            var panel = new PVPanel()
-                {
-                    Name = "test",
-                    Azimuth = 0,
-                    BaseAngle = MathHelpers.DegreeToRadians(23),
-                    DirtRatio = 0.05 / 365,
-                    Efficiency = 1,
-                    Height = 2000,
-                    Width = 1000,
-                    Latitude = coord.Latitude,
-                    Longitude = coord.Longitude,
-                    PeakPower = 0.3,
-                    PanelPeakAngle = MathHelpers.DegreeToRadians(90)
-                };
-            AppData.PVEGrid.SetCommonPanel(panel);
-        }
-    }
-
-    private void setCommonBattery()
-    {
-        AppData.BatteryStorage.SetCommonBattery(new BatteryBlock()
-            {
-                Id = Guid.NewGuid().ToString(),
-                Capacity = 10000,
-                InternalResistance = 0.1,
-                MaximumChargePower = 2000,
-                MaximumDischargePower = 2000
-            });
-    }
-
-    private void AddPanelToGroup(string groupId, double azimuth = 0, bool setAzimuth = false, int count = 1)
-    {
-        SetCommonPanel();
-        if (setAzimuth)
-        {
-            AppData.PVEGrid.CommonPanel.Azimuth = azimuth;
-        }
-        var addedPanelsId = AppData.PVEGrid.AddPanelToGroup(groupId, AppData.PVEGrid.CommonPanel, count).ToList();
-
     }
 }

--- a/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/PVESimulation.razor
+++ b/VirtualEconomyFramework/VEBlazor.EntitiesBlocks.Demo.Energy/Pages/PVESimulation.razor
@@ -53,7 +53,7 @@
             if (storeddata != null)
                 AppData.StoredBatteryStorageConfig = storeddata;
 
-            if (storeddata != null && !AppData.BatteryStorage.ImportConfigFromJson(storeddata))
+            if (storeddata != null && !AppData.BatteryStorage.ImportConfig(storeddata).Item1)
             {
                 setCommonBattery();
                 AppData.BatteryStorage.AddBatteryBlock(AppData.BatteryStorage.CommonBattery).ToList();
@@ -74,7 +74,7 @@
             if (storeddata != null)
                 AppData.StoredPVEConfig = storeddata;
 
-            if (storeddata != null && !AppData.PVEGrid.ImportConfigFromJson(storeddata))
+            if (storeddata != null && !AppData.PVEGrid.ImportConfig(storeddata).Item1)
             {
                 panelAzimuthE = MathHelpers.DegreeToRadians(-40);
                 panelAzimuthS = MathHelpers.DegreeToRadians(0);

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Consumers/ConsumerTDDSimulator.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Consumers/ConsumerTDDSimulator.cs
@@ -15,6 +15,10 @@ namespace VEDriversLite.EntitiesBlocks.Consumers
 {
     public class ConsumerTDDSimulator : CommonSimulator
     {
+        public ConsumerTDDSimulator()
+        {
+            Type = SimulatorTypes.TDDConsumption;
+        }
         public List<DataProfile> TDDs { get; set; } = new List<DataProfile>();
 
         public string Name { get; set; } = string.Empty;
@@ -122,7 +126,7 @@ namespace VEDriversLite.EntitiesBlocks.Consumers
                     name = Name;
 
                 var rblock = block.GetBlock(BlockType.Simulated,
-                                            BlockDirection.Created,
+                                            BlockDirection.Consumed,
                                             tmp,
                                             ts,
                                             amount,

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Consumers/ConsumerTDDSimulator.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Consumers/ConsumerTDDSimulator.cs
@@ -1,0 +1,148 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using VEDriversLite.EntitiesBlocks.Blocks;
+using VEDriversLite.EntitiesBlocks.Blocks.Dto;
+using VEDriversLite.EntitiesBlocks.Entities;
+using VEDriversLite.EntitiesBlocks.PVECalculations;
+
+namespace VEDriversLite.EntitiesBlocks.Consumers
+{
+    public class ConsumerTDDSimulator : CommonSimulator
+    {
+        public List<DataProfile> TDDs { get; set; } = new List<DataProfile>();
+
+        public string Name { get; set; } = string.Empty;
+
+        public override (bool, string) ExportConfig()
+        {
+            var res = JsonConvert.SerializeObject(TDDs);
+            return (true, res);
+        }
+        public override (bool, string) ImportConfig(string config)
+        {
+            if (!string.IsNullOrEmpty(config))
+            {
+                try
+                {
+                    var tds = JsonConvert.DeserializeObject<List<DataProfile>>(config);
+                    if (tds != null)
+                    {
+                        TDDs = tds;
+                        return (true, string.Empty);
+                    }
+                }
+                catch
+                {
+                    Console.WriteLine("Not standard config, trying to parse the TDD raw data...");
+                }
+
+                var tdds = ConsumersHelpers.LoadTDDs(config);
+                if (tdds != null)
+                {
+                    TDDs = tdds;
+                    return (true, string.Empty);
+                }
+            }
+            return (false, string.Empty);
+        }
+
+        public override IEnumerable<IBlock> GetBlocks(BlockTimeframe timeframe, DateTime start, DateTime end, Dictionary<string, DataProfile> inputProfiles, Dictionary<string, List<IBlock>> inputBlocks, Dictionary<string, object> options)
+        {
+            if (TDDs == null || (TDDs != null && TDDs.Count == 0))
+                throw new Exception($"Please import TDD data before use of simulator Id: {Id}.");
+            if (end < start)
+                throw new Exception($"Wrong input of the start and end in simulator Id: {Id}. End cannot be earlier than start.");
+
+            var block = new BaseBlock();
+
+            var sourceId = Id;
+            if (options.TryGetValue("sourceId", out var sid))
+                sourceId = sid as string;
+            var parentId = ParentId;
+            if (options.TryGetValue("parentId", out var pid))
+                parentId = pid as string;
+            var name = $"Block-{Name}";
+            if (options.TryGetValue("name", out var n))
+                name = n as string;
+            var tddIndex = -1;
+            if (options.TryGetValue("tddIndex", out var tix))
+                tddIndex = (int)tix;
+
+            start = start.AddHours(-start.Hour).AddMinutes(-start.Minute).AddSeconds(-start.Second);
+            end = end.AddHours(-end.Hour).AddMinutes(-end.Minute).AddSeconds(-end.Second);
+            var tmp = start;
+            var firstBlockId = string.Empty;
+
+            var ts = BlockHelpers.GetTimeSpanBasedOntimeframe(timeframe, start);
+
+            while (tmp < end)
+            {
+                var amount = 0.0;
+
+                var htmp = tmp;
+                var hend = htmp.Add(ts);
+                while (htmp < hend)
+                {
+                    var tot = 0.0;
+                    var tddmoment = htmp.AddMinutes(-htmp.Minute).AddSeconds(-htmp.Second).AddMilliseconds(-htmp.Millisecond);
+
+                    if (TDDs != null && tddIndex >= 0 && TDDs.Count > tddIndex)
+                    {
+                        if (TDDs[tddIndex].ProfileData.TryGetValue(tddmoment, out var value))
+                            tot = value;
+                    }
+                    else if (TDDs != null && tddIndex < 0 && TDDs.Count > 0)
+                    {
+                        foreach(var tdd in TDDs)
+                        {
+                            if (tdd.ProfileData.TryGetValue(tddmoment, out var value))
+                                tot += value;
+                        }
+                    }
+
+                    if (htmp.AddHours(1) < hend)
+                        amount += tot;
+                    else
+                        amount += tot * (hend - htmp).TotalHours;
+
+                    htmp = htmp.AddHours(1);
+                }
+
+                if (string.IsNullOrEmpty(sourceId))
+                    sourceId = Id;
+                if (string.IsNullOrEmpty(parentId))
+                    parentId = Id;
+                if (string.IsNullOrEmpty(name))
+                    name = Name;
+
+                var rblock = block.GetBlock(BlockType.Simulated,
+                                            BlockDirection.Created,
+                                            tmp,
+                                            ts,
+                                            amount,
+                                            sourceId,
+                                            name,
+                                            null,
+                                            parentId);
+
+                rblock.IsInDayOnly = true;
+                if (string.IsNullOrEmpty(firstBlockId))
+                    firstBlockId = rblock.Id;
+                else
+                    rblock.RepetitiveSourceBlockId = firstBlockId;
+
+                yield return rblock;
+
+                tmp = tmp.Add(ts);
+                ts = BlockHelpers.GetTimeSpanBasedOntimeframe(timeframe, tmp);
+            }
+        }
+        
+    }
+}

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Consumers/ConsumerTDDSimulator.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Consumers/ConsumerTDDSimulator.cs
@@ -19,6 +19,13 @@ namespace VEDriversLite.EntitiesBlocks.Consumers
         {
             Type = SimulatorTypes.TDDConsumption;
         }
+
+        public ConsumerTDDSimulator(List<DataProfile> tDDs)
+        {
+            Type = SimulatorTypes.TDDConsumption;
+            TDDs = tDDs;
+        }
+
         public List<DataProfile> TDDs { get; set; } = new List<DataProfile>();
 
         public string Name { get; set; } = string.Empty;

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs
@@ -93,6 +93,51 @@ namespace VEDriversLite.EntitiesBlocks.Entities
         public DateTime LastChange { get; set; } = DateTime.UtcNow;
 
         /// <summary>
+        /// Dictionary of simulators
+        /// </summary>
+        public ConcurrentDictionary<string, ISimulator> Simulators { get; set; } = new ConcurrentDictionary<string, ISimulator>();
+
+        /// <summary>
+        /// dd simulator to entity
+        /// </summary>
+        /// <param name="simulator"></param>
+        /// <param name="simulatorId"></param>
+        /// <returns></returns>
+        public virtual (bool,string) AddSimulator(ISimulator simulator)
+        {
+            if (simulator == null) return (false, "Simulator object cannot be null.");
+
+            if (string.IsNullOrEmpty(simulator.Id))
+                simulator.Id = Guid.NewGuid().ToString();
+
+            if (!Simulators.ContainsKey(simulator.Id))
+            {
+                simulator.ParentId = Id;
+                Simulators.TryAdd(simulator.Id, simulator);
+            }
+
+            LastChange = DateTime.UtcNow;
+            return (true, simulator.Id);
+        }
+
+        /// <summary>
+        /// Remove simulator from dictionary of Simulators
+        /// </summary>
+        /// <param name="simulators">List of Ids of blocks</param>
+        /// <returns></returns>
+        public virtual (bool,string) RemoveSimulator(List<string> simulatorIds)
+        {
+            if (simulatorIds == null) return (false,string.Empty);
+            foreach (var simulator in simulatorIds)
+            {
+                if (Simulators.ContainsKey(simulator))
+                    Simulators.TryRemove(simulator, out var sim);
+            }
+            LastChange = DateTime.UtcNow;
+            return (true, string.Empty);
+        }
+
+        /// <summary>
         /// Try to add the block to the Blocks dictionary. Block must have unique hashs
         /// </summary>
         /// <param name="block"></param>

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs
@@ -405,9 +405,9 @@ namespace VEDriversLite.EntitiesBlocks.Entities
         public virtual IEnumerable<IBlock> GetBlocks(List<BlockDirection> justThisDirections = null,
                                               List<BlockType> justThisType = null)
         {
-            if (justThisDirections != null && justThisDirections.Count > 0)
+            if (justThisDirections != null && justThisDirections.Count > 0 && justThisType == null)
                 return Blocks.Values.Where(b => justThisDirections.Contains(b.Direction)).OrderBy(b => b.StartTime);
-            else if (justThisType != null && justThisType.Count > 0)
+            else if (justThisType != null && justThisType.Count > 0 && justThisDirections == null)
                 return Blocks.Values.Where(b => justThisType.Contains(b.Type)).OrderBy(b => b.StartTime);
             else if (justThisType != null && justThisType.Count > 0 && justThisDirections != null && justThisDirections.Count > 0)
                 return Blocks.Values.Where(b => justThisType.Contains(b.Type) && justThisDirections.Contains(b.Direction)).OrderBy(b => b.StartTime);

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonSimulator.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonSimulator.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VEDriversLite.EntitiesBlocks.Blocks;
+using VEDriversLite.EntitiesBlocks.Blocks.Dto;
+
+namespace VEDriversLite.EntitiesBlocks.Entities
+{
+    public abstract class CommonSimulator : ISimulator
+    {
+        /// <summary>
+        /// Id of simulator
+        /// </summary>
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        /// <summary>
+        /// Parent Id of this simulator
+        /// </summary>
+        public string ParentId { get; set; } = string.Empty;
+        /// <summary>
+        /// Loaded config for simulator
+        /// </summary>
+        public string LoadedConfig { get; set; } = string.Empty;
+        /// <summary>
+        /// Type of simulator
+        /// </summary>
+        public SimulatorTypes Type { get; set; } = SimulatorTypes.None;
+        /// <summary>
+        /// Import config of simulator
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public abstract (bool, string) ImportConfig(string config);
+        /// <summary>
+        /// Export simulator configuration as string
+        /// </summary>
+        /// <returns></returns>
+        public abstract (bool, string) ExportConfig();
+        public virtual DataProfile GetData(BlockTimeframe timeframe, DateTime start, DateTime end, Dictionary<string, DataProfile> inputProfiles, Dictionary<string, List<IBlock>> inputBlocks, Dictionary<string, object> options)
+        {
+            var res = GetBlocks(timeframe, start, end, inputProfiles, inputBlocks, options).ToList();
+            var result = DataProfileHelpers.ConvertBlocksToDataProfile(res);
+            return result;
+        }
+        public abstract IEnumerable<IBlock> GetBlocks(BlockTimeframe timeframe, DateTime start, DateTime end, Dictionary<string, DataProfile> inputProfiles, Dictionary<string, List<IBlock>> inputBlocks, Dictionary<string, object> options);
+        
+    }
+}

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/IEntity.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/IEntity.cs
@@ -124,7 +124,8 @@ namespace VEDriversLite.EntitiesBlocks.Entities
                                     DateTime endtime,
                                     bool takeConsumptionAsInvert = false,
                                     List<BlockDirection> justThisDirections = null,
-                                    List<BlockType> justThisType = null);
+                                    List<BlockType> justThisType = null,
+                                    bool addSimulators = true);
 
         /// <summary>
         /// Optimized Get list of the blocks based on setup timespan and step and specific timegrame
@@ -141,7 +142,8 @@ namespace VEDriversLite.EntitiesBlocks.Entities
                                              DateTime endtime,
                                              bool takeConsumptionAsInvert = false,
                                              List<BlockDirection> justThisDirections = null,
-                                             List<BlockType> justThisType = null);
+                                             List<BlockType> justThisType = null,
+                                             bool addSimulators = true);
 
         /// <summary>
         /// Get list of the repetitive blocks based on setup timespan and step and specific timegrame
@@ -157,7 +159,8 @@ namespace VEDriversLite.EntitiesBlocks.Entities
                                                       DateTime endtime,
                                                       bool takeConsumptionAsInvert = false,
                                                       List<BlockDirection> justThisDirections = null,
-                                                      List<BlockType> justThisType = null);
+                                                      List<BlockType> justThisType = null, 
+                                                      bool addSimulators = true);
 
         /// <summary>
         /// Get list of the blocks based on setup timespan and step and specific timegrame and window
@@ -181,7 +184,8 @@ namespace VEDriversLite.EntitiesBlocks.Entities
                                                   bool invertWindow = false,
                                                   bool takeConsumptionAsInvert = false,
                                                   List<BlockDirection> justThisDirections = null,
-                                                  List<BlockType> justThisType = null);
+                                                  List<BlockType> justThisType = null,
+                                                  bool addSimulators = true);
         /// <summary>
         /// Get total consumption over all blocks
         /// </summary>

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/IEntity.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/IEntity.cs
@@ -50,6 +50,10 @@ namespace VEDriversLite.EntitiesBlocks.Entities
         /// </summary>
         DateTime LastChange { get; set; }
         /// <summary>
+        /// Dictionary of simulators
+        /// </summary>
+        ConcurrentDictionary<string, ISimulator> Simulators { get; set; }
+        /// <summary>
         /// Try to add the block to the Blocks dictionary. Block must have unique hashs
         /// </summary>
         /// <param name="blocks"></param>
@@ -183,5 +187,17 @@ namespace VEDriversLite.EntitiesBlocks.Entities
         /// </summary>
         /// <returns></returns>
         double GetTotalSummedValue(bool includeNotConsumedYet = true);
+        /// <summary>
+        /// Add simulator to entity
+        /// </summary>
+        /// <param name="simulator"></param>
+        /// <returns></returns>
+        (bool,string) AddSimulator(ISimulator simulator);
+        /// <summary>
+        /// Remove simulator
+        /// </summary>
+        /// <param name="simulatorIds"></param>
+        /// <returns></returns>
+        (bool,string) RemoveSimulator(List<string> simulatorIds);
     }
 }

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/IEntity.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/IEntity.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using VEDriversLite.Common.Calendar;
 using VEDriversLite.EntitiesBlocks.Blocks;
 
 namespace VEDriversLite.EntitiesBlocks.Entities
@@ -27,7 +28,14 @@ namespace VEDriversLite.EntitiesBlocks.Entities
         /// Name of the entity
         /// </summary>
         string Name { get; set; }
+        /// <summary>
+        /// Entity description
+        /// </summary>
         string Description { get; set; }
+        /// <summary>
+        /// Entity location
+        /// </summary>
+        Coordinates Coords { get; set; }
         /// <summary>
         /// Parent Id of the entity
         /// </summary>
@@ -111,6 +119,26 @@ namespace VEDriversLite.EntitiesBlocks.Entities
                                              BlockDirection? direction = null,
                                              DateTime? startTime = null,
                                              TimeSpan? timeframe = null);
+
+        /// <summary>
+        /// Get blocks from simulators for specific timerage and timeframe
+        /// </summary>
+        /// <param name="timeframe"></param>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <returns></returns>
+        List<IBlock> GetSimulatorsBlocks(BlockTimeframe timeframe,
+                                         DateTime start,
+                                         DateTime end);
+
+        /// <summary>
+        /// Get blocks filtered based on Directions or Types
+        /// </summary>
+        /// <param name="justThisDirections">List of all allowed Direction of blocks</param>
+        /// <param name="justThisType">List of all Types of blocks</param>
+        /// <returns></returns>
+        IEnumerable<IBlock> GetBlocks(List<BlockDirection> justThisDirections = null,
+                                      List<BlockType> justThisType = null);
 
         /// <summary>
         /// Get summed values as list of the blocks based on setup timespan and step.

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/ISimulator.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/ISimulator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VEDriversLite.EntitiesBlocks.Blocks;
+using VEDriversLite.EntitiesBlocks.Blocks.Dto;
+
+namespace VEDriversLite.EntitiesBlocks.Entities
+{
+    public enum SimulatorTypes
+    {
+        None,
+        PVE,
+        Battery,
+        TDDConsumption,
+        Custom
+    }
+    public interface ISimulator
+    {
+        /// <summary>
+        /// Id of simulator
+        /// </summary>
+        string Id { get; set; }
+        /// <summary>
+        /// Parent Id of this simulator
+        /// </summary>
+        string ParentId { get; set; }
+        /// <summary>
+        /// Loaded config for simulator
+        /// </summary>
+        string LoadedConfig { get; set; }
+        /// <summary>
+        /// Type of simulator
+        /// </summary>
+        SimulatorTypes Type { get; set; }
+        DataProfile GetData(BlockTimeframe timeframe, DateTime start, DateTime end, Dictionary<string,DataProfile> inputProfiles, Dictionary<string, List<IBlock>> inputBlocks, Dictionary<string,object> options);
+        IEnumerable<IBlock> GetBlocks(BlockTimeframe timeframe, DateTime start, DateTime end, Dictionary<string,DataProfile> inputProfiles, Dictionary<string, List<IBlock>> inputBlocks, Dictionary<string,object> options);
+        (bool, string) ImportConfig(string config);
+        (bool, string) ExportConfig();
+    }
+}

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/CommonEntitiesHandler.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/CommonEntitiesHandler.cs
@@ -290,9 +290,59 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
         }
 
         /// <summary>
+        /// Add simulator to specific entity
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="simulator"></param>
+        /// <returns></returns>
+        public virtual (bool, string) AddSimulatorToEntity(string id, ISimulator simulator)
+        {
+            if (string.IsNullOrEmpty(id))
+                return (false, "Cannot add simulator to the entity. Entity id cannot be empty.");
+            if (simulator == null)
+                return (false, $"Cannot add simulator to the entity {id}, block cannot be empty.");
+
+            if (Entities.TryGetValue(id, out var entity))
+            {
+                var res = entity.AddSimulator(simulator);
+                if (res.Item1)
+                    return (true, $"Simulator {res.Item2} added to the entity {entity.Name} - {id}.");
+                else
+                    return (true, $"Cannot add simulator to the entity {entity.Name} - {id}. Error: {res.Item2}");
+            }
+            else
+                return (false, $"Cannot add simulator to the entity. Entity {id} is not in Entities list. Add the entity first please.");
+
+        }
+        /// <summary>
+        /// Remove simulators from entity. You can add multiple Ids in one command
+        /// </summary>
+        /// <param name="simulatorIds"></param>
+        /// <returns></returns>
+        public virtual (bool, string) RemoveSimulatorsFromEntity(string id, List<string> simulatorIds)
+        {
+            if (string.IsNullOrEmpty(id))
+                return (false, "Cannot remove simulator from the entity. Entity id cannot be empty.");
+            if (simulatorIds == null)
+                return (false, $"Cannot remove simulator from the entity {id}, simulators ids cannot be empty.");
+
+            if (Entities.TryGetValue(id, out var entity))
+            {
+                var res = entity.RemoveSimulator(simulatorIds);
+                if (res.Item1)
+                    return (true, $"Simulators removed from the entity {entity.Name} - {id}.");
+                else
+                    return (true, $"Cannot remove simulators from the entity {entity.Name} - {id}.");
+            }
+            else
+                return (false, $"Cannot remove simulators from the entity. Source {id} is not in Entities list. Add the consumer first please.");
+
+        }
+
+        /// <summary>
         /// Add block to the entity. 
         /// </summary>
-        /// <param name="id">Id of the consumer</param>
+        /// <param name="id">Id of the entity</param>
         /// <param name="block">Block</param>
         /// <returns></returns>
         public virtual (bool, string) AddBlockToEntity(string id, IBlock block)
@@ -317,7 +367,7 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
         /// Add block to the entity. 
         /// This param override of AddBlockToEntity will split block based on AlocationScheme to several entities
         /// </summary>
-        /// <param name="id">Id of the consumer</param>
+        /// <param name="id">Id of the entity</param>
         /// <param name="block">Block</param>
         /// <param name="alocationSchemeId">Alocation Scheme Id</param>
         /// <returns></returns>
@@ -373,7 +423,7 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
         /// <summary>
         /// Add blocks to the entity. 
         /// </summary>
-        /// <param name="id">Id of the consumer</param>
+        /// <param name="id">Id of the entity</param>
         /// <param name="blocks">list of the Blocks</param>
         /// <returns></returns>
         public virtual (bool, string) AddBlocksToEntity(string id, List<IBlock> blocks)
@@ -398,7 +448,7 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
         /// Add blocks to the entity. 
         /// This param override of AddBlockToEntity will split block based on AlocationScheme to several entities
         /// </summary>
-        /// <param name="id">Id of the consumer</param>
+        /// <param name="id">Id of the entity</param>
         /// <param name="block">Block</param>
         /// <param name="alocationSchemeId">Alocation Scheme Id</param>
         /// <returns></returns>
@@ -463,9 +513,9 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
         }
 
         /// <summary>
-        /// Change block parameters to the consumer. 
+        /// Change block parameters to the entity. 
         /// </summary>
-        /// <param name="id">Id of the consumer</param>
+        /// <param name="id">Id of the entity</param>
         /// <param name="type">type of Block</param>
         /// <returns></returns>
         public virtual (bool, string) ChangEntityBlockParameters(string id,
@@ -479,9 +529,9 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                                                  TimeSpan? timeframe = null)
         {
             if (string.IsNullOrEmpty(id))
-                return (false, "Cannot change blocks to the consumer. Consumer id cannot be empty.");
+                return (false, "Cannot change blocks to the entity. Entity id cannot be empty.");
             if (string.IsNullOrEmpty(blockId))
-                return (false, "Cannot change blocks to the consumer. Block id cannot be empty.");
+                return (false, "Cannot change blocks to the entity. Block id cannot be empty.");
 
             if (Entities.TryGetValue(id, out var entity))
             {
@@ -490,35 +540,35 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                     return (true, $"Block {blockId} in {entity.Name} - {id} paramters changed.");
                 }
                 else
-                    return (true, $"Cannot add blocks to the consumer {entity.Name} - {id}");
+                    return (true, $"Cannot add blocks to the entity {entity.Name} - {id}");
             }
             else
-                return (false, $"Cannot add blocks to the consumer. Consumer {id} is not in Consumers list. Add the consumer first please.");
+                return (false, $"Cannot add blocks to the consumer. Entity {id} is not in entities list. Add the consumer first please.");
         }
 
 
         /// <summary>
         /// Remove blocks from the entity. 
         /// </summary>
-        /// <param name="id">Id of the consumer</param>
+        /// <param name="id">Id of the entity</param>
         /// <param name="blocks">list of the Ids of the Blocks</param>
         /// <returns></returns>
         public virtual (bool, string) RemoveBlocksFromEntity(string id, List<string> blocks)
         {
             if (string.IsNullOrEmpty(id))
-                return (false, "Cannot remove blocks from the consumer. Consumer id cannot be empty.");
+                return (false, "Cannot remove blocks from the entity. Entity id cannot be empty.");
             if (blocks == null)
-                return (false, $"Cannot remove blocks from the consumer {id}, blocks cannot be empty.");
+                return (false, $"Cannot remove blocks from the entity {id}, blocks cannot be empty.");
 
             if (Entities.TryGetValue(id, out var entity))
             {
                 if (entity.RemoveBlocks(blocks))
-                    return (true, $"Blocks removed from the consumer {entity.Name} - {id}.");
+                    return (true, $"Blocks removed from the entity {entity.Name} - {id}.");
                 else
-                    return (true, $"Cannot remove blocks from the consumer {entity.Name} - {id}.");
+                    return (true, $"Cannot remove blocks from the entity {entity.Name} - {id}.");
             }
             else
-                return (false, $"Cannot remove blocks from the consumer. Source {id} is not in Consumers list. Add the consumer first please.");
+                return (false, $"Cannot remove blocks from the entity. Source {id} is not in Entities list. Add the consumer first please.");
         }
 
         /// <summary>

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/CommonEntitiesHandler.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/CommonEntitiesHandler.cs
@@ -662,7 +662,8 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                                                 bool withSubConsumers = true, 
                                                                 bool takeConsumptionAsInvert = false,
                                                                 List<BlockDirection> justThisDirections = null,
-                                                                List < BlockType > justThisType = null)
+                                                                List < BlockType > justThisType = null,
+                                                                bool addSimulators = true)
         {
 
             if (string.IsNullOrEmpty(entityId))
@@ -670,7 +671,13 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
 
             if (Entities.TryGetValue(entityId, out var entity))
             {
-                var mainres = entity.GetSummedValuesOptimized(timeframesteps, starttime, endtime, takeConsumptionAsInvert, justThisDirections, justThisType);
+                var mainres = entity.GetSummedValuesOptimized(timeframesteps, 
+                                                              starttime, 
+                                                              endtime, 
+                                                              takeConsumptionAsInvert, 
+                                                              justThisDirections, 
+                                                              justThisType, 
+                                                              addSimulators);
 
                 if (withSubConsumers && mainres != null)
                 {
@@ -686,20 +693,24 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                         {
                             foreach (var childId in e.Children)
                             {
+                                if (Entities.TryGetValue(childId, out var sbc))
                                 {
-                                    if (Entities.TryGetValue(childId, out var sbc))
-                                    {
-                                        tmpEntity.AddBlocks(sbc.BlocksOrderByTime.ToList());
+                                    tmpEntity.AddBlocks(sbc.BlocksOrderByTime.ToList());
 
-                                        if (sbc.IsParent)
-                                            queue.Enqueue(sbc);
-                                    }
+                                    if (sbc.IsParent)
+                                        queue.Enqueue(sbc);
                                 }
                             }
                         }
                     }
 
-                    var re = tmpEntity.GetSummedValuesOptimized(timeframesteps, starttime, endtime, takeConsumptionAsInvert, justThisDirections, justThisType);
+                    var re = tmpEntity.GetSummedValuesOptimized(timeframesteps, 
+                                                                starttime, 
+                                                                endtime, 
+                                                                takeConsumptionAsInvert, 
+                                                                justThisDirections, 
+                                                                justThisType, 
+                                                                addSimulators);
                     if (re != null)
                     {
                         foreach(var block in re.Where(r => r.Amount > 0 || r.Amount < 0))
@@ -782,7 +793,8 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                                                           bool withSubConsumers = true, 
                                                                           bool takeConsumptionAsInvert = false,
                                                                           List<BlockDirection> justThisDirections = null,
-                                                                          List<BlockType> justThisType = null)
+                                                                          List<BlockType> justThisType = null,
+                                                                          bool addSimulators = true)
         {
 
             if (string.IsNullOrEmpty(entityId))
@@ -798,7 +810,8 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                                                   invertWindow, 
                                                                   takeConsumptionAsInvert, 
                                                                   justThisDirections,
-                                                                  justThisType);
+                                                                  justThisType,
+                                                                  addSimulators);
 
                 if (withSubConsumers && mainres != null)
                 {
@@ -836,7 +849,8 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                                                     invertWindow,
                                                                     takeConsumptionAsInvert, 
                                                                     justThisDirections,
-                                                                    justThisType);
+                                                                    justThisType, 
+                                                                    addSimulators);
                     if (re != null)
                     {
                         foreach (var block in re.Where(r => r.Amount > 0 || r.Amount < 0))

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/IEntitiesHandler.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/IEntitiesHandler.cs
@@ -68,6 +68,19 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
         /// <returns></returns>
         (bool, string) AddBlocksToEntity(string id, List<IBlock> blocks);
         /// <summary>
+        /// Add simulator to specific entity
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="simulator"></param>
+        /// <returns></returns>
+        (bool, string) AddSimulatorToEntity(string id, ISimulator simulator);
+        /// <summary>
+        /// Remove simulators from entity. You can add multiple Ids in one command
+        /// </summary>
+        /// <param name="simulatorIds"></param>
+        /// <returns></returns>
+        (bool, string) RemoveSimulatorsFromEntity(string id, List<string> simulatorIds);
+        /// <summary>
         /// Change block parameters to the consumer. 
         /// </summary>
         /// <param name="id">Id of the consumer</param>

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/IEntitiesHandler.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Handlers/IEntitiesHandler.cs
@@ -155,7 +155,8 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                             bool withSubConsumers = true,
                                             bool takeConsumptionAsInvert = false,
                                             List<BlockDirection> justThisDirections = null, 
-                                            List<BlockType> justThisType = null);
+                                            List<BlockType> justThisType = null,
+                                            bool addSimulators = true);
         /// <summary>
         /// Get all Blocks with the all childern blocks
         /// </summary>
@@ -188,7 +189,8 @@ namespace VEDriversLite.EntitiesBlocks.Handlers
                                                       bool withSubConsumers = true,
                                                       bool takeConsumptionAsInvert = false,
                                                       List<BlockDirection> justThisDirections = null,
-                                                      List<BlockType> justThisType = null);
+                                                      List<BlockType> justThisType = null,
+                                                      bool addSimulators = true);
         /// <summary>
         /// Get recalculated power consumption represented as list of Blocks split based on setted timegrame
         /// </summary>

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/PVECalculations/PVPanelsGroupsHandler.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/PVECalculations/PVPanelsGroupsHandler.cs
@@ -27,6 +27,10 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
     /// </summary>
     public class PVPanelsGroupsHandler : CommonSimulator
     {
+        public PVPanelsGroupsHandler()
+        {
+            Type = SimulatorTypes.PVE;
+        }
         /// <summary>
         /// Name of the PV Panels Groups = whole PVE block
         /// </summary>
@@ -755,11 +759,6 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
             var name = $"Block-{Name}";
             if (options.TryGetValue("name", out var n))
                 name = n as string;
-            var coord = new Coordinates(49.194103, 16.608998);
-            if (options.TryGetValue("latitude", out var lt))
-                coord.Latitude = (double)lt;
-            if (options.TryGetValue("longitude", out var lg))
-                coord.Longitude = (double)lg;
             var weatherFactor = 0.0;
             if (options.TryGetValue("weatherFactor", out var wf))
                weatherFactor = (double)wf;
@@ -781,7 +780,10 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
                 {
                     var tot = 0.0;
                     foreach (var group in PVPanelsGroups.Values)
-                        tot += group.GetGroupPeakPowerInDateTime(htmp, coord, weatherFactor);
+                        tot += group.GetGroupPeakPowerInDateTime(htmp, 
+                                                                 new Coordinates(group.MedianLatitude, 
+                                                                                 group.MedianLongitude), 
+                                                                 weatherFactor);
 
                     if (htmp.AddHours(1) < hend)
                         amount += tot;

--- a/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/PVECalculations/PVPanelsGroupsHandler.cs
+++ b/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/PVECalculations/PVPanelsGroupsHandler.cs
@@ -2,14 +2,19 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using System.Xml.Linq;
 using VEDriversLite.Common;
 using VEDriversLite.Common.Calendar;
 using VEDriversLite.EntitiesBlocks.Blocks;
+using VEDriversLite.EntitiesBlocks.Blocks.Dto;
+using VEDriversLite.EntitiesBlocks.Entities;
 using VEDriversLite.EntitiesBlocks.Financial;
 using VEDriversLite.EntitiesBlocks.PVECalculations.Dto;
 
@@ -20,12 +25,8 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
     /// For example two sides of house with 5 panels can has own PVPanelGroup both. 
     /// Both will be agregated through PVPanelsGroupsHandler class to act as one whole PVE
     /// </summary>
-    public class PVPanelsGroupsHandler
+    public class PVPanelsGroupsHandler : CommonSimulator
     {
-        /// <summary>
-        /// Id of panels groups
-        /// </summary>
-        public string Id { get; set; } = Guid.NewGuid().ToString();
         /// <summary>
         /// Name of the PV Panels Groups = whole PVE block
         /// </summary>
@@ -199,7 +200,7 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
                 return false;
             if (PVPanelsGroups.TryGetValue(groupId, out var group))
             {
-                if(group.RemovePanel(panelId))
+                if (group.RemovePanel(panelId))
                 {
                     Refresh();
                     return true;
@@ -212,19 +213,19 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
         /// Export Config file to the Json
         /// </summary>
         /// <returns></returns>
-        public string ExportSettingsToJSON()
+        public override (bool, string) ExportConfig()
         {
             try
             {
                 var exp = JsonConvert.SerializeObject(CreateConfigFile());
                 if (exp != null)
-                    return exp;
+                    return (true, exp);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Console.WriteLine("Cannot serialize PVE settings. " + ex.Message);
             }
-            return string.Empty;
+            return (false, string.Empty);
         }
 
         /// <summary>
@@ -254,16 +255,16 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
         /// </summary>
         /// <param name="jsonConfig"></param>
         /// <returns></returns>
-        public bool ImportConfigFromJson(string jsonConfig)
+        public override (bool, string) ImportConfig(string jsonConfig)
         {
             if (string.IsNullOrEmpty(jsonConfig))
-                return false;
+                return (false, string.Empty);
 
             var config = JsonConvert.DeserializeObject<PVConfigDto>(jsonConfig);
             if (config != null)
-                return ImportConfig(config);
+                return (ImportConfigDto(config), string.Empty);
             else
-                return false;
+                return (false, string.Empty);
         }
 
         /// <summary>
@@ -271,7 +272,7 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
         /// </summary>
         /// <param name="config"></param>
         /// <returns></returns>
-        public bool ImportConfig(PVConfigDto config)
+        public bool ImportConfigDto(PVConfigDto config)
         {
             if (config == null)
                 return false;
@@ -282,11 +283,11 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
 
             PVPanelsGroups.Clear();
 
-            foreach(var group in config.Groups.Values)
+            foreach (var group in config.Groups.Values)
             {
-                var gr = new PVPanelsGroup() 
-                { 
-                    Id = group.Id, 
+                var gr = new PVPanelsGroup()
+                {
+                    Id = group.Id,
                     Name = group.Name
                 };
                 foreach (var panel in group.Panels.Values)
@@ -391,12 +392,12 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
             if (string.IsNullOrEmpty(groupId))
                 return null;
             var amount = 0.0;
-            
+
             if (PVPanelsGroups.TryGetValue(groupId, out var group))
                 amount = group.GetGroupPeakPowerInDateTime(start, coord, weatherFactor);
 
             var block = new BaseBlock();
-            return block.GetBlock(BlockType.Simulated, BlockDirection.Created, start, new TimeSpan(1, 0, 0), amount, groupId, Name, null, groupId);         
+            return block.GetBlock(BlockType.Simulated, BlockDirection.Created, start, new TimeSpan(1, 0, 0), amount, groupId, Name, null, groupId);
         }
 
         /// <summary>
@@ -584,12 +585,12 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
         /// <param name="coord">Coordinates on planet</param>
         /// <param name="weatherFactor">Weather efficiency factor</param>
         /// <returns>Peak energy in specific datetime in form of List of IBlock for whole one year</returns>
-        public IEnumerable<IBlock> GetTotalPeakPowerInTimeframeBlocks(DateTime start, 
-                                                                      DateTime end, 
-                                                                      Coordinates coord, 
-                                                                      double weatherFactor, 
-                                                                      string parentId = "", 
-                                                                      string sourceId = "", 
+        public IEnumerable<IBlock> GetTotalPeakPowerInTimeframeBlocks(DateTime start,
+                                                                      DateTime end,
+                                                                      Coordinates coord,
+                                                                      double weatherFactor,
+                                                                      string parentId = "",
+                                                                      string sourceId = "",
                                                                       string name = "")
         {
             if (end < start)
@@ -685,8 +686,8 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
 
                 foreach (var group in PVPanelsGroups.Values)
                     amount += group.GetGroupPeakPowerInDateTime(tmp, coord, weatherFactor);
-                
-                
+
+
                 if (string.IsNullOrEmpty(sourceId))
                     sourceId = Id;
                 if (string.IsNullOrEmpty(parentId))
@@ -728,9 +729,96 @@ namespace VEDriversLite.EntitiesBlocks.PVECalculations
         public double GetTotalPowerInDateTime(DateTime start, Coordinates coord, double weatherFactor)
         {
             var result = 0.0;
-            foreach(var group in PVPanelsGroups.Values)
+            foreach (var group in PVPanelsGroups.Values)
                 result += group.GetGroupPeakPowerInDateTime(start, coord, weatherFactor);
             return result;
+        }
+
+        public override IEnumerable<IBlock> GetBlocks(BlockTimeframe timeframe, 
+                                                      DateTime start, 
+                                                      DateTime end, 
+                                                      Dictionary<string, DataProfile> inputProfiles, 
+                                                      Dictionary<string, List<IBlock>> inputBlocks, 
+                                                      Dictionary<string, object> options)
+        {
+            if (end < start)
+                throw new Exception("Wrong input of the start and end. End cannot be earlier than start.");
+
+            var block = new BaseBlock();
+
+            var sourceId = Id;
+            if (options.TryGetValue("sourceId", out var sid))
+                sourceId = sid as string;
+            var parentId = ParentId;
+            if (options.TryGetValue("parentId", out var pid))
+                parentId = pid as string;
+            var name = $"Block-{Name}";
+            if (options.TryGetValue("name", out var n))
+                name = n as string;
+            var coord = new Coordinates(49.194103, 16.608998);
+            if (options.TryGetValue("latitude", out var lt))
+                coord.Latitude = (double)lt;
+            if (options.TryGetValue("longitude", out var lg))
+                coord.Longitude = (double)lg;
+            var weatherFactor = 0.0;
+            if (options.TryGetValue("weatherFactor", out var wf))
+               weatherFactor = (double)wf;
+
+            start = start.AddHours(-start.Hour).AddMinutes(-start.Minute).AddSeconds(-start.Second);
+            end = end.AddHours(-end.Hour).AddMinutes(-end.Minute).AddSeconds(-end.Second);
+            var tmp = start;
+            var firstBlockId = string.Empty;
+
+            var ts = BlockHelpers.GetTimeSpanBasedOntimeframe(timeframe, start);
+
+            while (tmp < end)
+            {
+                var amount = 0.0;
+                
+                var htmp = tmp;
+                var hend = htmp.Add(ts);
+                while (htmp < hend)
+                {
+                    var tot = 0.0;
+                    foreach (var group in PVPanelsGroups.Values)
+                        tot += group.GetGroupPeakPowerInDateTime(htmp, coord, weatherFactor);
+
+                    if (htmp.AddHours(1) < hend)
+                        amount += tot;
+                    else
+                        amount += tot * (hend - htmp).TotalHours;
+
+                    htmp = htmp.AddHours(1);
+                }
+
+                if (string.IsNullOrEmpty(sourceId))
+                    sourceId = Id;
+                if (string.IsNullOrEmpty(parentId))
+                    parentId = Id;
+                if (string.IsNullOrEmpty(name))
+                    name = Name;
+
+                var rblock = block.GetBlock(BlockType.Simulated,
+                                            BlockDirection.Created,
+                                            tmp,
+                                            ts,
+                                            amount,
+                                            sourceId,
+                                            name,
+                                            null,
+                                            parentId);
+
+                rblock.IsInDayOnly = true;
+                if (string.IsNullOrEmpty(firstBlockId))
+                    firstBlockId = rblock.Id;
+                else
+                    rblock.RepetitiveSourceBlockId = firstBlockId;
+
+                yield return rblock;
+
+                tmp = tmp.Add(ts);
+                ts = BlockHelpers.GetTimeSpanBasedOntimeframe(timeframe, tmp);
+            }
         }
 
     }

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Blocks/AddBlock.razor
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Blocks/AddBlock.razor
@@ -163,6 +163,8 @@
                 Block.RepetitiveFirstRun = DateTime.Now;
             if (Block.RepetitiveEndRun == null)
                 Block.RepetitiveEndRun = DateTime.Now.AddDays(1);
+            if (Block.OffPeriod == null)
+                Block.OffPeriod = new TimeSpan(1, 0, 0);
         }
         await InvokeAsync(StateHasChanged);
     }

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/AppData.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/AppData.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using VEDriversLite.Common.Calendar;
+using VEDriversLite.EntitiesBlocks.Blocks.Dto;
 using VEDriversLite.EntitiesBlocks.Handlers;
 using VEDriversLite.EntitiesBlocks.PVECalculations;
 using VEDriversLite.EntitiesBlocks.StorageCalculations;
@@ -22,7 +24,11 @@ namespace VEFramework.VEBlazor.EntitiesBlocks.Services
         public string StoredBatteryStorageConfig { get; set; } = string.Empty;
         public TreeItem SelectedItem { get; set; } = new TreeItem();
         public bool PVESimulatorLoaded { get; set; }
+        public Coordinates DefaultCoordinates = new Coordinates(49.194103, 16.608998);
+
         public bool BatteryStorageSimulatorLoaded { get; set; }
+        public bool TDDsLoaded { get; set; }
+        public List<DataProfile> TDDs { get; set; } = new List<DataProfile>();
 
     }
 }

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
@@ -128,6 +128,7 @@ public partial class CalculationService
                         var ent = eGrid.GetEntity(om.Key, EntityType.Consumer);
                         if (ent != null)
                         {
+                            Console.WriteLine($"Adding TDD simulator to entity {ent.Name}...");
                             eGrid.AddSimulatorToEntity(ent.Id,
                                        new ConsumerTDDSimulator(new List<DataProfile>() { appData.TDDs[0] }));
 
@@ -301,9 +302,9 @@ public partial class CalculationService
 
                                     if (devicephase.TryGetValue(om.Key, out var phasedata))
                                     {
-                                        var consumedByDevice = Math.Round(firstmeasurespot.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
-                                                                                          .Where(b => b.Amount > 0)
-                                                                                          .Select(b => b.Amount).Sum(), 4);
+                                        var consumedByDevice = Math.Round(ent.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                                                .Where(b => b.Amount != 0)
+                                                                                .Select(b => b.Amount).Sum(), 4);
 
                                         var forwardedByDevice = Math.Round(phasedata.Item1.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
                                         var notCoveredByPVEInDevice = Math.Round(phasedata.Item2.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
@@ -315,6 +316,7 @@ public partial class CalculationService
                                             OverProductionFromFVE = forwardedByDevice,
                                             Deficiency = notCoveredByPVEInDevice
                                         };
+                                        Console.WriteLine($"{Newtonsoft.Json.JsonConvert.SerializeObject(calculationResult, Newtonsoft.Json.Formatting.Indented)}");
 
                                         if (result.ContainsKey(om.Key))
                                         {

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
@@ -63,8 +63,8 @@ public partial class CalculationService
         var pvesource = eGrid.GetEntity("617132c1-2f70-4d98-bdb1-18f9f01c29ef", EntityType.Source);
         eGrid.RemoveAllEntityBlocks(pvesource.Id);
 
-        var fmsId = deviceLeadingMap.Where(d => d.Value).FirstOrDefault();
-        var firstmeasurespot = eGrid.GetEntity(fmsId.Key, EntityType.Consumer);
+        //var fmsId = deviceLeadingMap.Where(d => d.Value).FirstOrDefault();
+        var firstmeasurespot = eGrid.GetEntity(pvesource.ParentId, EntityType.Consumer);
         eGrid.RemoveAllEntityBlocks(firstmeasurespot.Id);
 
         //var firstmeasurespotDevice = eGrid.FindEntityByName("firstspotdevice");
@@ -77,7 +77,7 @@ public partial class CalculationService
 
         var coord = new Coordinates(PVESim.MedianLatitude, PVESim.MedianLongitude);
 
-        if (pvesource != null)
+        if (network != null && pvesource != null && firstmeasurespot != null && mainbattery != null)
         {
             // add PVE simulator to entity
             eGrid.AddSimulatorToEntity(pvesource.Id, PVESim);

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
@@ -52,6 +52,12 @@ public partial class CalculationService
         if (!PVESim.ImportConfig(filteredPveConfig).Item1) return null;
         if (!StorageSim.ImportConfig(filteredStorageConfig).Item1) return null;
 
+        // load financial info
+        PVESim.FinancialInfo.Discont.DiscontInPercentagePerYear = (double)interestRate;
+        PVESim.FinancialInfo.BuyDate = new DateTime(2022,1,1);
+        StorageSim.FinancialInfo.Discont.DiscontInPercentagePerYear = (double)interestRate;
+        StorageSim.FinancialInfo.BuyDate = new DateTime(2022, 1, 1);
+
         var network = eGrid.GetEntity("7b27c442-ad40-4679-b6d5-8873d9763996", EntityType.Consumer);
         eGrid.RemoveAllEntityBlocks(network.Id);
         var pvesource = eGrid.GetEntity("617132c1-2f70-4d98-bdb1-18f9f01c29ef", EntityType.Source);
@@ -71,13 +77,15 @@ public partial class CalculationService
 
         var coord = new Coordinates(PVESim.MedianLatitude, PVESim.MedianLongitude);
 
-        var tddfromfile = await httpClient.GetStringAsync("tdd.csv");
-        var tdds = new List<DataProfile>();
-        if (tddfromfile != null)
-            tdds = ConsumersHelpers.LoadTDDs(tddfromfile);
-
         if (pvesource != null)
         {
+            // add PVE simulator to entity
+            eGrid.AddSimulatorToEntity(pvesource.Id, PVESim);
+
+            // add TDD Consumption simulators to entities
+            eGrid.AddSimulatorToEntity(firstmeasurespot.Id,
+                                       new ConsumerTDDSimulator(new List<DataProfile>() { appData.TDDs[0] }));
+            
             var dtmp = start;
             var dend = endDate;
 
@@ -87,26 +95,7 @@ public partial class CalculationService
             while (dtmp < dend)
             {
                 Console.WriteLine($"Analysing {dtmp} Day {day} of {totalDays} total Days to analyze...");
-                // simulate production for each hour of day
-                var productionblocks = PVESim.GetTotalPeakPowerInHourTimeframeBlocks(dtmp,
-                                                                                     dtmp.AddDays(1),
-                                                                                     coord, 1.0,
-                                                                                     pvesource.Id).ToList();
-
-                // add day production blocks to the mainPVE entity
-                eGrid.AddBlocksToEntity(pvesource.Id, productionblocks);
-
-                // get consumption based on TDD for MeasureSpot1 (place where the PVE is connected through)
-                // it will cover whole consumption of this entity. 
-                var consumptionblocks = ConsumersHelpers.GetConsumptionBlocksBasedOnTDD(tdds[0],
-                                                                                        dtmp,
-                                                                                        dtmp.AddDays(1),
-                                                                                        BlockTimeframe.Hour,
-                                                                                        firstmeasurespot.Id);
-
-                // add day consumption blocks to the device in Frist Measure Spot entity
-                eGrid.AddBlocksToEntity(firstmeasurespot.Id, consumptionblocks.Item1);
-
+                
                 // get two list of blocks after first phase of calculation,
                 // when first measured spot (connection place for PVE) consume imediatelly what it can
                 // the first list contains rest of the production after the consumption by entity.
@@ -116,16 +105,18 @@ public partial class CalculationService
                 // keep Id connection between source and rest blocks
                 foreach (var b in firstmeasuredspotPhase1.Item1)
                 {
-                    var bs = productionblocks.Where(bl => bl.StartTime == b.StartTime).FirstOrDefault();
+                    var bs = pvesource.Blocks.Values.Where(bl => bl.StartTime == b.StartTime).FirstOrDefault();
                     if (bs != null)
                         b.Id = bs.Id;
                 }
 
-                eGrid.RemoveAllEntityBlocks(firstmeasurespot.Id);
-                eGrid.RemoveAllEntityBlocks(pvesource.Id);
-
+                // add rest of consumption
                 eGrid.AddBlocksToEntity(firstmeasurespot.Id, firstmeasuredspotPhase1.Item2);
+                // add receipts blocks
+                eGrid.AddBlocksToEntity(firstmeasurespot.Id, BlockHelpers.CloneBlocks(firstmeasuredspotPhase1.Item1, true, true, BlockType.Forwarded).ToList());
+                eGrid.AddBlocksToEntity(firstmeasurespot.Id, BlockHelpers.CloneBlocks(firstmeasuredspotPhase1.Item2, true, true, BlockType.NotCovered).ToList());
 
+                // add rest of production
                 eGrid.AddBlocksToEntity(network.Id, firstmeasuredspotPhase1.Item1, alocationScheme.Id);
 
                 var consumptions = new Dictionary<string, (List<IBlock>, DataProfile)>();
@@ -137,30 +128,27 @@ public partial class CalculationService
                         var ent = eGrid.GetEntity(om.Key, EntityType.Consumer);
                         if (ent != null)
                         {
-                            eGrid.RemoveAllEntityBlocks(ent.Id);
-
-                            var conblks = ConsumersHelpers.GetConsumptionBlocksBasedOnTDD(tdds[0],
-                                                                                         dtmp,
-                                                                                         dtmp.AddDays(1),
-                                                                                         BlockTimeframe.Hour,
-                                                                                         ent.Id);
-
-                            eGrid.AddBlocksToEntity(ent.Id, conblks.Item1);
-                            consumptions.TryAdd(ent.Id, conblks);
+                            eGrid.AddSimulatorToEntity(ent.Id,
+                                       new ConsumerTDDSimulator(new List<DataProfile>() { appData.TDDs[0] }));
 
                             var devicePhase = GetEntityBalanceBlocksAfterAlocationOfPVEBlocks(ent, eGrid, dtmp);
                             foreach (var b in devicePhase.Item1)
                             {
-                                var bs = consumptionblocks.Item1.Where(bl => bl.StartTime == b.StartTime).FirstOrDefault();
+                                var bs = ent.Blocks.Values.Where(bl => bl.StartTime == b.StartTime).FirstOrDefault();
                                 if (bs != null)
                                     b.Id = bs.Id;
                             }
+
                             devicephase.TryAdd(ent.Id, devicePhase);
 
-                            eGrid.RemoveAllEntityBlocks(ent.Id);
+                            // add rest of consumption to entity
                             eGrid.AddBlocksToEntity(ent.Id, devicePhase.Item2);
-                            eGrid.AddBlocksToEntity(network.Id, devicePhase.Item1);
+                            // add receipts blocks
+                            eGrid.AddBlocksToEntity(ent.Id, BlockHelpers.CloneBlocks(devicePhase.Item1, true, true, BlockType.Forwarded).ToList());
+                            eGrid.AddBlocksToEntity(ent.Id, BlockHelpers.CloneBlocks(devicePhase.Item2, true, true, BlockType.NotCovered).ToList());
 
+                            // add rest of overproduced to network
+                            eGrid.AddBlocksToEntity(network.Id, devicePhase.Item1);
                         }
                     }
                 }
@@ -174,7 +162,8 @@ public partial class CalculationService
                                                                     true,
                                                                     true,
                                                                     new List<BlockDirection>() { BlockDirection.Created },
-                                                                    new List<BlockType>() { BlockType.Simulated });
+                                                                    new List<BlockType>() { BlockType.Simulated },
+                                                                    false);
 
                 var productionPhase3Profile = DataProfileHelpers.ConvertBlocksToDataProfile(productionPhase3);
 
@@ -186,7 +175,8 @@ public partial class CalculationService
                                                                      true,
                                                                      true,
                                                                      new List<BlockDirection>() { BlockDirection.Consumed },
-                                                                     new List<BlockType>() { BlockType.Simulated });
+                                                                     new List<BlockType>() { BlockType.Simulated },
+                                                                     false);
 
                 var consumptionPhase3Profile = DataProfileHelpers.ConvertBlocksToDataProfile(consumptionPhase3);
 
@@ -235,7 +225,8 @@ public partial class CalculationService
                                                                 true,
                                                                 true,
                                                                 new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
-                                                                new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real });
+                                                                new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real },
+                                                                false);
 
                         // get consumption of the whole network in the day in window of Day Tariff
                         var netwDT = eGrid.GetConsumptionOfEntityWithWindow(network.Id,
@@ -248,7 +239,8 @@ public partial class CalculationService
                                                                             true,
                                                                             true,
                                                                             new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
-                                                                            new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real });
+                                                                            new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real },
+                                                                            false);
 
                         // get consumption of the whole network in the day in window of Night Tariff (set invertWindow parameter as true)
                         var netwNT = eGrid.GetConsumptionOfEntityWithWindow(network.Id,
@@ -261,7 +253,8 @@ public partial class CalculationService
                                                                             true,
                                                                             true,
                                                                             new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
-                                                                            new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real });
+                                                                            new List<BlockType>() { BlockType.Simulated, BlockType.Calculated, BlockType.Real },
+                                                                            false);
 
 
 
@@ -276,47 +269,62 @@ public partial class CalculationService
                         var totalNTOverProduction = Math.Round(netwNT.Where(b => b.Amount > 0).Select(b => b.Amount).Sum(), 4);
 
                         // total produced from own PVE
-                        var totalproduced = Math.Round(productionblocks.Where(b => b.Amount > 0).Select(b => b.Amount).Sum(), 4);
-                        // total produced from own PVE over the consumption during the production phase of PVE
+                        var pveproduced = pvesource.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                               .Where(b => b.Amount > 0)
+                                                               .Select(b => b.Amount);
+                        var totalproduced = Math.Round(pveproduced.Sum(), 4);// total produced from own PVE over the consumption during the production phase of PVE
                         var totalOverProducedAfterConsumedImmediately = Math.Round(productionPhase3Profile.ProfileData.Values.Sum(), 4);
                         // total stored in storage from PVE production
                         var totalStored = Math.Round(dch.ProfileData.Values.Sum(), 4);
                         // total used from storage for consumption 
                         var totalUsedFromStorage = Math.Round(ddisch.ProfileData.Values.Sum() / 1000, 4);
 
-
                         // total consumption from first measure spot (base on tdd here)
-                        var totalConsumptionFirstMeasureSpot = Math.Round(consumptionblocks.Item2.DataSum, 4);
+                        var consumedFirstMS = firstmeasurespot.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                              .Where(b => b.Amount > 0)
+                                                              .Select(b => b.Amount);
+                        var totalConsumptionFirstMeasureSpot = Math.Round(consumedFirstMS.Sum(), 4);
                         // device not consumed and forwarded up
                         var totalfirstmeasurespotForwardedSourceBlocks = Math.Round(firstmeasuredspotPhase1.Item1.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
                         // device not covered
                         var totalfirstmeasureSpotNotCoveredConsuptionBlocks = Math.Round(firstmeasuredspotPhase1.Item2.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
                         // total consumption on device 
 
-                        foreach(var data in consumptions)
+                        foreach(var om in deviceLeadingMap)
                         {
-                            Console.WriteLine($"Device Id: {data.Key}.");
-                            if (devicephase.TryGetValue(data.Key, out var phasedata))
+                            if (!om.Value)
                             {
-                                var consumedByDevice = Math.Round(data.Value.Item2.DataSum, 4);
-                                var forwardedByDevice = Math.Round(phasedata.Item1.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
-                                var notCoveredByPVEInDevice = Math.Round(phasedata.Item2.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
-                                
-                                var calculationResult = new CalculationResult()
+                                var ent = eGrid.GetEntity(om.Key, EntityType.Consumer);
+                                if (ent != null)
                                 {
-                                    Date = dtmp,
-                                    ConsumedFromFVE = consumedByDevice,
-                                    OverProductionFromFVE = forwardedByDevice,
-                                    Deficiency = notCoveredByPVEInDevice
-                                };
-                                
-                                if (result.ContainsKey(data.Key))
-                                {
-                                    result[data.Key].Add(calculationResult);
-                                }
-                                else
-                                {
-                                    result.Add(data.Key, new List<CalculationResult>() { calculationResult });
+                                    Console.WriteLine($"Device Id: {om.Key}.");
+
+                                    if (devicephase.TryGetValue(om.Key, out var phasedata))
+                                    {
+                                        var consumedByDevice = Math.Round(firstmeasurespot.GetSimulatorsBlocks(BlockTimeframe.Hour, dtmp, dtmp.AddDays(1))
+                                                                                          .Where(b => b.Amount > 0)
+                                                                                          .Select(b => b.Amount).Sum(), 4);
+
+                                        var forwardedByDevice = Math.Round(phasedata.Item1.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
+                                        var notCoveredByPVEInDevice = Math.Round(phasedata.Item2.Where(b => b.Amount != 0).Select(b => b.Amount).Sum(), 4);
+
+                                        var calculationResult = new CalculationResult()
+                                        {
+                                            Date = dtmp,
+                                            ConsumedFromFVE = consumedByDevice,
+                                            OverProductionFromFVE = forwardedByDevice,
+                                            Deficiency = notCoveredByPVEInDevice
+                                        };
+
+                                        if (result.ContainsKey(om.Key))
+                                        {
+                                            result[om.Key].Add(calculationResult);
+                                        }
+                                        else
+                                        {
+                                            result.Add(om.Key, new List<CalculationResult>() { calculationResult });
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -389,7 +397,8 @@ public partial class CalculationService
                                                 true,
                                                 true,
                                                 new List<BlockDirection>() { BlockDirection.Created, BlockDirection.Consumed },
-                                                new List<BlockType>() { BlockType.Simulated });
+                                                new List<BlockType>() { BlockType.Simulated },
+                                                true);
 
         var consprof = DataProfileHelpers.ConvertBlocksToDataProfile(cons);
         // get production after some part was consumed with sun-day consumption

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs
@@ -16,9 +16,6 @@ namespace VEFramework.VEBlazor.EntitiesBlocks.Services;
 
 public partial class CalculationService
 {
-    [Inject]
-    public HttpClient Http { get; set; }
-
     private async Task<Dictionary<string, List<CalculationResult>>> DoCalculation(string filteredEntitiesConfig, string filteredPveConfig, string filteredStorageConfig,
         decimal budget, decimal interestRate, DateTime endDate, IDictionary<string, bool> deviceLeadingMap)
     {
@@ -52,8 +49,8 @@ public partial class CalculationService
 
         // load simulators
         if (!eGrid.LoadFromConfig(filteredEntitiesConfig).Item1) return null;
-        if (!PVESim.ImportConfigFromJson(filteredPveConfig)) return null;
-        if (!StorageSim.ImportConfigFromJson(filteredStorageConfig)) return null;
+        if (!PVESim.ImportConfig(filteredPveConfig).Item1) return null;
+        if (!StorageSim.ImportConfig(filteredStorageConfig).Item1) return null;
 
         var network = eGrid.GetEntity("7b27c442-ad40-4679-b6d5-8873d9763996", EntityType.Consumer);
         eGrid.RemoveAllEntityBlocks(network.Id);

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.cs
@@ -35,7 +35,7 @@ public partial class CalculationService
             var filteredPveConfig = appData.PVEGrid.ExportConfig().Item2;
             var filteredStorageConfig = appData.BatteryStorage.ExportConfig().Item2;
             await DoCalculation(filteredEntitiesConfig, filteredPveConfig, filteredStorageConfig,
-                                budget, interestRate, new DateTime(2022,1,1), deviceLeadingMap );
+                                budget, interestRate, new DateTime(2022,1,2), deviceLeadingMap );
         }
         finally
         {

--- a/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.cs
+++ b/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.cs
@@ -22,8 +22,8 @@ public partial class CalculationService
         decimal budget, decimal interestRate)
     {
         var (_, oldEntitiesConfig) = appData.EntitiesHandler.ExportToConfig();
-        var oldPveConfig = appData.PVEGrid.ExportSettingsToJSON();
-        var oldStorageConfig = appData.BatteryStorage.ExportSettingsToJSON();
+        var oldPveConfig = appData.PVEGrid.ExportConfig().Item2;
+        var oldStorageConfig = appData.BatteryStorage.ExportConfig().Item2;
 
 
         try
@@ -32,16 +32,16 @@ public partial class CalculationService
             FilterPve(calculationEntities);
             FilterStorage(calculationEntities);
             var (_, filteredEntitiesConfig) = appData.EntitiesHandler.ExportToConfig();
-            var filteredPveConfig = appData.PVEGrid.ExportSettingsToJSON();
-            var filteredStorageConfig = appData.BatteryStorage.ExportSettingsToJSON();
+            var filteredPveConfig = appData.PVEGrid.ExportConfig().Item2;
+            var filteredStorageConfig = appData.BatteryStorage.ExportConfig().Item2;
             await DoCalculation(filteredEntitiesConfig, filteredPveConfig, filteredStorageConfig,
                                 budget, interestRate, new DateTime(2022,1,1), deviceLeadingMap );
         }
         finally
         {
             appData.EntitiesHandler.LoadFromConfig(oldEntitiesConfig);
-            appData.PVEGrid.ImportConfigFromJson(oldEntitiesConfig);
-            appData.BatteryStorage.ImportConfigFromJson(oldEntitiesConfig);
+            appData.PVEGrid.ImportConfig(oldEntitiesConfig);
+            appData.BatteryStorage.ImportConfig(oldEntitiesConfig);
         }
         
         return;

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/BlockEntities/EntitiesSimulators.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/BlockEntities/EntitiesSimulators.cs
@@ -143,7 +143,7 @@ namespace VEFrameworkUnitTest.BlockEntities
                 foreach (var cons in consumption)
                     total += cons.Amount;
 
-                Assert.Equal(consumptionPerHour * 24 * days, total);
+                Assert.Equal(-consumptionPerHour * 24 * days, total);
             }
         }
 
@@ -175,7 +175,7 @@ namespace VEFrameworkUnitTest.BlockEntities
                 foreach (var cons in consumption)
                     total += cons.Amount;
 
-                Assert.Equal((consumptionPerHour + consumptionPerHour2) * 24 * days, total);
+                Assert.Equal(-(consumptionPerHour + consumptionPerHour2) * 24 * days, total);
             }
         }
 

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/BlockEntities/EntitiesSimulators.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/BlockEntities/EntitiesSimulators.cs
@@ -1,0 +1,295 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VEDriversLite.Common;
+using VEDriversLite.Common.Calendar;
+using VEDriversLite.EntitiesBlocks.Blocks;
+using VEDriversLite.EntitiesBlocks.Blocks.Dto;
+using VEDriversLite.EntitiesBlocks.Consumers;
+using VEDriversLite.EntitiesBlocks.Entities;
+using VEDriversLite.EntitiesBlocks.PVECalculations;
+using Xunit;
+
+namespace VEFrameworkUnitTest.BlockEntities
+{
+    public class EntitiesSimulators
+    {
+        private PVPanelsGroupsHandler PVEGrid = new PVPanelsGroupsHandler();
+        private Coordinates coord = new Coordinates(49.194103, 16.608998);
+
+        private DataProfile CreateDummyYearTDD(double amount = 1.0)
+        {
+            var result = new DataProfile();
+
+            var start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var end = start.AddYears(1);
+
+            var tmp = start;
+            while(tmp < end)
+            {
+                result.ProfileData.TryAdd(tmp, amount);
+                tmp = tmp.AddHours(1);
+            }
+
+            return result;
+        }
+
+        private PVPanel GetCommonPanel()
+        {
+            return new PVPanel()
+            {
+                Name = "test",
+                Azimuth = 0,
+                BaseAngle = MathHelpers.DegreeToRadians(23),
+                DirtRatio = 0.05 / 365,
+                Efficiency = 1,
+                Height = 2000,
+                Width = 1000,
+                Latitude = coord.Latitude,
+                Longitude = coord.Longitude,
+                PeakPower = 1,
+                PanelPeakAngle = MathHelpers.DegreeToRadians(90)
+            };
+        }
+
+        [Fact]
+        public void PVESimulatorInEntityTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var firstJuly2022PVE1kWhProduction = 0.975166397260274;
+            var days = 1;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var PVESim = new PVPanelsGroupsHandler();
+            PVESim.SetCommonPanel(GetCommonPanel());
+            var southPanelsId = PVESim.AddGroup("South");
+            PVESim.AddPanelToGroup(southPanelsId, PVESim.CommonPanel, 1).ToList();
+
+            var addsimres = entity.AddSimulator(PVESim);
+            if (addsimres.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Hour, start, end, true, null, null, true);
+                Assert.Equal(24 * days, consumption.Count);
+
+                var total = 0.0;
+                foreach(var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal(firstJuly2022PVE1kWhProduction, total);
+            }
+        }
+
+        [Fact]
+        public void TwoPVESimulatorsInEntityTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var firstJuly2022PVE1kWhProduction = 0.975166397260274;
+            var days = 1;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var PVESim = new PVPanelsGroupsHandler();
+            PVESim.SetCommonPanel(GetCommonPanel());
+            var southPanelsId = PVESim.AddGroup("South");
+            PVESim.AddPanelToGroup(southPanelsId, PVESim.CommonPanel, 1).ToList();
+
+
+            var PVESim2 = new PVPanelsGroupsHandler();
+            PVESim2.SetCommonPanel(GetCommonPanel());
+            var southPanelsId2 = PVESim2.AddGroup("South");
+            PVESim2.AddPanelToGroup(southPanelsId2, PVESim2.CommonPanel, 1).ToList();
+
+            var addsimres = entity.AddSimulator(PVESim);
+            var addsimres2 = entity.AddSimulator(PVESim2);
+            if (addsimres.Item1 && addsimres2.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Hour, start, end, true, null, null, true);
+                Assert.Equal(24 * days, consumption.Count);
+
+                var total = 0.0;
+                foreach (var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal(2 * firstJuly2022PVE1kWhProduction, total);
+            }
+        }
+
+        [Fact]
+        public void TDDSimulatorInEntityTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var consumptionPerHour = 1;
+            var days = 1;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var tddSim = new ConsumerTDDSimulator();
+            tddSim.TDDs.Add(CreateDummyYearTDD(consumptionPerHour));
+
+            var addsimres = entity.AddSimulator(tddSim);
+            if (addsimres.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Hour, start, end, true, null, null, true);
+                Assert.Equal(24 * days, consumption.Count);
+
+                var total = 0.0;
+                foreach (var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal(consumptionPerHour * 24 * days, total);
+            }
+        }
+
+        [Fact]
+        public void TwoTDDSimulatorInEntityTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var consumptionPerHour = 1;
+            var consumptionPerHour2 = 2;
+            var days = 1;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var tddSim = new ConsumerTDDSimulator();
+            tddSim.TDDs.Add(CreateDummyYearTDD(consumptionPerHour));
+
+            var tddSim2 = new ConsumerTDDSimulator();
+            tddSim2.TDDs.Add(CreateDummyYearTDD(consumptionPerHour2));
+
+            var addsimres = entity.AddSimulator(tddSim);
+            var addsimres2 = entity.AddSimulator(tddSim2);
+            if (addsimres.Item1 && addsimres2.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Hour, start, end, true, null, null, true);
+                Assert.Equal(24 * days, consumption.Count);
+
+                var total = 0.0;
+                foreach (var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal((consumptionPerHour + consumptionPerHour2) * 24 * days, total);
+            }
+        }
+
+        [Fact]
+        public void TDDandPVESimulatorInEntityTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var firstJuly2022PVE1kWhProduction = 0.975166397260274;
+            var consumptionPerHour = 1;
+            var days = 1;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var PVESim = new PVPanelsGroupsHandler();
+            PVESim.SetCommonPanel(GetCommonPanel());
+            var southPanelsId = PVESim.AddGroup("South");
+            PVESim.AddPanelToGroup(southPanelsId, PVESim.CommonPanel, 1).ToList();
+
+            var tddSim = new ConsumerTDDSimulator();
+            tddSim.TDDs.Add(CreateDummyYearTDD(consumptionPerHour));
+
+            var addsimres = entity.AddSimulator(tddSim);
+            var addsimres1 = entity.AddSimulator(PVESim);
+
+            if (addsimres.Item1 && addsimres1.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Hour, start, end, true, null, null, true);
+                Assert.Equal(24 * days, consumption.Count);
+
+                var total = 0.0;
+                foreach (var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal(firstJuly2022PVE1kWhProduction - consumptionPerHour * 24 * days, total);
+            }
+        }
+
+        [Fact]
+        public void TwoTDDandPVESimulatorInEntityTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var firstJuly2022PVE1kWhProduction = 0.975166397260274;
+            var consumptionPerHour = 1;
+            var consumptionPerHour1 = 2;
+            var days = 1;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var PVESim = new PVPanelsGroupsHandler();
+            PVESim.SetCommonPanel(GetCommonPanel());
+            var southPanelsId = PVESim.AddGroup("South");
+            PVESim.AddPanelToGroup(southPanelsId, PVESim.CommonPanel, 1).ToList();
+
+            var tddSim = new ConsumerTDDSimulator();
+            tddSim.TDDs.Add(CreateDummyYearTDD(consumptionPerHour));
+            var tddSim1 = new ConsumerTDDSimulator();
+            tddSim1.TDDs.Add(CreateDummyYearTDD(consumptionPerHour1));
+
+            var addsimres = entity.AddSimulator(tddSim);
+            var addsimres1 = entity.AddSimulator(tddSim1);
+            var addsimres2 = entity.AddSimulator(PVESim);
+
+            if (addsimres.Item1 && addsimres1.Item1 && addsimres2.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Hour, start, end, true, null, null, true);
+                Assert.Equal(24 * days, consumption.Count);
+
+                var total = 0.0;
+                foreach (var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal(firstJuly2022PVE1kWhProduction - (consumptionPerHour + consumptionPerHour1) * 24 * days, total);
+            }
+        }
+
+        [Fact]
+        public void TwoTDDandPVESimulatorInEntityDayFrameTest()
+        {
+            DateTime start = new DateTime(2022, 1, 1, 0, 0, 0);
+            var PVE1kWh2022YearProduction = 577.9884758630136;
+            var consumptionPerHour = 1;
+            var consumptionPerHour1 = 2;
+            var days = 365;
+            var end = start.AddDays(days);
+
+            var entity = new BaseEntity();
+
+            var PVESim = new PVPanelsGroupsHandler();
+            PVESim.SetCommonPanel(GetCommonPanel());
+            var southPanelsId = PVESim.AddGroup("South");
+            PVESim.AddPanelToGroup(southPanelsId, PVESim.CommonPanel, 1).ToList();
+
+            var tddSim = new ConsumerTDDSimulator();
+            tddSim.TDDs.Add(CreateDummyYearTDD(consumptionPerHour));
+            var tddSim1 = new ConsumerTDDSimulator();
+            tddSim1.TDDs.Add(CreateDummyYearTDD(consumptionPerHour1));
+
+            var addsimres = entity.AddSimulator(tddSim);
+            var addsimres1 = entity.AddSimulator(tddSim1);
+            var addsimres2 = entity.AddSimulator(PVESim);
+
+            if (addsimres.Item1 && addsimres1.Item1 && addsimres2.Item1)
+            {
+                var consumption = entity.GetSummedValues(BlockTimeframe.Day, start, end, true, null, null, true);
+                Assert.Equal(days, consumption.Count);
+
+                var total = 0.0;
+                foreach (var cons in consumption)
+                    total += cons.Amount;
+
+                Assert.Equal(PVE1kWh2022YearProduction - (consumptionPerHour + consumptionPerHour1) * 24 * days, total);
+            }
+        }
+    }
+}

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/BlockEntities/EntitiesTests.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/BlockEntities/EntitiesTests.cs
@@ -823,5 +823,271 @@ namespace VEFrameworkUnitTest.BlockEntities
                 Assert.Equal(hours * 4, res.Count());
             }
         }
+
+
+        [Fact]
+        public void GetPowerConsumptionOfEntitySpecifiedBlockTypes()
+        {
+            var entity = new BaseEntity();
+
+            // add some custom blocks of simulated consumption
+            var blockstoadd = new List<IBlock>();
+            var starttime = new DateTime(2022, 1, 1, 0, 0, 0);
+            var timeframe = new TimeSpan(168, 0, 0);
+            var endtime = starttime + timeframe;
+
+            var timeframe2 = new TimeSpan(336, 0, 0);
+
+            var Block = new BaseBlock();
+            var consumption = 1;
+            var consumption2 = 2;
+
+            //device which consume 1kW and run 168 hours, started on 1st of January in 0:00, for example PC
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.Simulated,
+                                                  BlockDirection.Consumed,
+                                                  starttime,
+                                                  timeframe,
+                                                  consumption,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            //device which consume 1kW and run 336 hours, started on 3rd of January in 0:00, for example PC
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.Forwarded,
+                                                  BlockDirection.Consumed,
+                                                  starttime.AddDays(3),
+                                                  timeframe2,
+                                                  consumption2,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            entity.AddBlocks(blockstoadd);
+
+            if (entity != null)
+            {
+                var hours = 4;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour, starttime, starttime.AddHours(hours));
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(4, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour,
+                                                 starttime,
+                                                 starttime.AddHours(hours),
+                                                 false,
+                                                 new List<BlockDirection>(),
+                                                 new List<BlockType>() { BlockType.Simulated, BlockType.Forwarded });
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption + (hours - 3 * 24) * consumption2, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour, 
+                                                 starttime, 
+                                                 starttime.AddHours(hours), 
+                                                 false, 
+                                                 new List<BlockDirection>(), 
+                                                 new List<BlockType>() {  BlockType.Simulated });
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption, total);
+                Assert.Equal(hours, res.Count());
+            }
+        }
+
+        [Fact]
+        public void GetPowerConsumptionOfEntitySpecifiedBlockDirections()
+        {
+            var entity = new BaseEntity();
+
+            // add some custom blocks of simulated consumption
+            var blockstoadd = new List<IBlock>();
+            var starttime = new DateTime(2022, 1, 1, 0, 0, 0);
+            var timeframe = new TimeSpan(168, 0, 0);
+            var endtime = starttime + timeframe;
+
+            var timeframe2 = new TimeSpan(336, 0, 0);
+
+            var Block = new BaseBlock();
+            var consumption = 1;
+            var consumption2 = 2;
+
+            //device which consume 1kW and run 168 hours, started on 1st of January in 0:00, for example PC
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.Simulated,
+                                                  BlockDirection.Consumed,
+                                                  starttime,
+                                                  timeframe,
+                                                  consumption,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            //device which consume 1kW and run 336 hours, started on 3rd of January in 0:00, for example PC
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.Simulated,
+                                                  BlockDirection.Created,
+                                                  starttime.AddDays(3),
+                                                  timeframe2,
+                                                  consumption2,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            entity.AddBlocks(blockstoadd);
+
+            if (entity != null)
+            {
+                var hours = 4;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour, starttime, starttime.AddHours(hours));
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(4, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour,
+                                                 starttime,
+                                                 starttime.AddHours(hours),
+                                                 false,
+                                                 new List<BlockDirection>() {  BlockDirection.Consumed, BlockDirection.Created });
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption + (hours - 3 * 24) * consumption2, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour,
+                                                 starttime,
+                                                 starttime.AddHours(hours),
+                                                 false,
+                                                 new List<BlockDirection>() { BlockDirection.Consumed});
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption, total);
+                Assert.Equal(hours, res.Count());
+            }
+        }
+
+        [Fact]
+        public void GetPowerConsumptionOfEntitySpecifiedBlockTypeAndDirections()
+        {
+            var entity = new BaseEntity();
+
+            // add some custom blocks of simulated consumption
+            var blockstoadd = new List<IBlock>();
+            var starttime = new DateTime(2022, 1, 1, 0, 0, 0);
+            var timeframe = new TimeSpan(168, 0, 0);
+            var endtime = starttime + timeframe;
+
+            var timeframe2 = new TimeSpan(336, 0, 0);
+
+            var Block = new BaseBlock();
+            var consumption = 1;
+            var consumption2 = 2;
+
+            //device which consume 1kW and run 168 hours, started on 1st of January in 0:00, for example PC
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.Simulated,
+                                                  BlockDirection.Consumed,
+                                                  starttime,
+                                                  timeframe,
+                                                  consumption,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            //device which consume 1kW and run 336 hours, started on 3rd of January in 0:00, for example PC
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.Forwarded,
+                                                  BlockDirection.Created,
+                                                  starttime.AddDays(3),
+                                                  timeframe2,
+                                                  consumption2,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            blockstoadd.Add(Block.GetBlockByPower(BlockType.NotCovered,
+                                                  BlockDirection.Created,
+                                                  starttime.AddDays(3),
+                                                  timeframe2,
+                                                  consumption2,
+                                                  ebth.sourceName,
+                                                  ebth.device2Id));
+
+            entity.AddBlocks(blockstoadd);
+
+            if (entity != null)
+            {
+                var hours = 4;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour, starttime, starttime.AddHours(hours));
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(4, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour,
+                                                 starttime,
+                                                 starttime.AddHours(hours),
+                                                 false,
+                                                 new List<BlockDirection>() { BlockDirection.Consumed, BlockDirection.Created },
+                                                 new List<BlockType>() { BlockType.Simulated, BlockType.Forwarded, BlockType.NotCovered });
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption + 2 * (hours - 3 * 24) * consumption2, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour,
+                                                 starttime,
+                                                 starttime.AddHours(hours),
+                                                 false,
+                                                 new List<BlockDirection>() { BlockDirection.Consumed, BlockDirection.Created },
+                                                 new List<BlockType>() { BlockType.Simulated, BlockType.Forwarded });
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption + (hours - 3 * 24) * consumption2, total);
+                Assert.Equal(hours, res.Count());
+            }
+
+            if (entity != null)
+            {
+                var hours = 168;
+                var res = entity.GetSummedValues(BlockTimeframe.Hour,
+                                                 starttime,
+                                                 starttime.AddHours(hours),
+                                                 false,
+                                                 new List<BlockDirection>() { BlockDirection.Consumed },
+                                                 new List<BlockType>() { BlockType.Simulated });
+                var total = 0.0;
+                foreach (var b in res)
+                    total += b.Amount;
+                Assert.Equal(hours * consumption, total);
+                Assert.Equal(hours, res.Count());
+            }
+        }
     }
 }

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Energy/PVESimulator/PVESimulation.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Energy/PVESimulator/PVESimulation.cs
@@ -160,11 +160,11 @@ namespace VEFrameworkUnitTest.Energy.PVESimulator
             AddPanelToGroup(southPanelsId, panelAzimuthS, true, 6);
             AddPanelToGroup(westPanelsId, panelAzimuthW, true, 8);
 
-            var config = PVEGrid.ExportSettingsToJSON();
+            var config = PVEGrid.ExportConfig();
 
             PVEGrid = new PVPanelsGroupsHandler();
 
-            PVEGrid.ImportConfigFromJson(config);
+            PVEGrid.ImportConfig(config.Item2);
 
             Assert.Equal(17, PVEGrid.PanelCount);
             Assert.Equal(49.194103, PVEGrid.MedianLatitude);

--- a/VirtualEconomyFramework/VEFrameworkUnitTest/Energy/StorageSimulator/BatteryStorageSimulationTests.cs
+++ b/VirtualEconomyFramework/VEFrameworkUnitTest/Energy/StorageSimulator/BatteryStorageSimulationTests.cs
@@ -219,13 +219,13 @@ namespace VEFrameworkUnitTest.Energy.StorageSimulator
                 MaximumDischargePower = 2000
             }).ToList();
 
-            var export = storage.ExportSettingsToJSON();
+            var export = storage.ExportConfig().Item2;
 
             var storage1 = CreateStorage();
             storage1.Id = "";
             storage1.Name = "";
 
-            if (storage1.ImportConfigFromJson(export))
+            if (storage1.ImportConfig(export).Item1)
             {
                 Assert.Equal("mainbattery", storage1.Name);
                 Assert.Equal(20000, storage1.TotalCapacity);


### PR DESCRIPTION
This merge brings [ISimulator interface](https://github.com/fyziktom/VirtualEconomyFramework/blob/151-EntitiesBlocks-storage-ui/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/ISimulator.cs) to provide simulator of consumption or production of blocks inside of IEntity.

Each IEntity has [dictionary of the simulators](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs#L113).
Simulator can be loaded [through handler](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs#L650) or directly through IEntity object.

There are two simulators available now. The PVESimulator and TDD Consumption simulator (battery is WIP). Both are used in [the demo](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs#L556).

The simulators are called when the Summedvalue of entity is requested. [It is here](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs#L435). This function creates empty result blocks and combines them with simulated blocks if any simulator is available. The call of simulators is [here](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/VEDriversLite.EntitiesBlocks/Entities/CommonEntity.cs#L332). It can load some parameters/options for simulator or some input DataProfiles or IBlocks lists. This function can be called for draw graph of day simulation of production or consumption also.

GetConsumptionOfEntity function has new parameter now. It allow the simulators during calculation. For example [here it is off](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/TestVEDriversLite/EntitiesBlocksTests.cs#L768). It is last bool parameter of this function. In this phase of calculation the blocks are already created, recalculated (based on cover of consumption by PVE) and added to entities. Oposite, at start of calculation there was no blocks in entities so simulators flag was on to create new blocks by simulators during calculating summedvalues of entity.

The simulation of entity blocks are used in the demo calculation in [energy demo app](https://github.com/fyziktom/VirtualEconomyFramework/blob/152965842baadf5e517dea8a4d50fecdc5f6881c/VirtualEconomyFramework/VEFramework.VEBlazor.EntitiesBlocks/Services/CalculationService.Inner.cs#L305).